### PR TITLE
chore(flow): rename Flow Network → Flow Harness + cleanup system + skill updates

### DIFF
--- a/.jarvis/context/README.md
+++ b/.jarvis/context/README.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This directory is the canonical knowledge base for the Flow Network workspace. AI agents, Jarvis CLI, and human contributors read these files for project context.
+This directory is the canonical knowledge base for the Flow Harness workspace. AI agents, Jarvis CLI, and human contributors read these files for project context.
 
 ## Loading Order
 
@@ -71,7 +71,7 @@ Files may start with `{{global}}`. This is a **Jarvis CLI feature** that include
 
 ## Tiers
 
-- **Workspace-level** (this directory): Shared Flow Network truth
+- **Workspace-level** (this directory): Shared Flow Harness truth
 - **Project-level** (e.g. `Flow/.jarvis/context/`): Project-specific overrides and implementation details
 - Project-level files take precedence when working inside a specific sub-project
 

--- a/.jarvis/context/decisions.md
+++ b/.jarvis/context/decisions.md
@@ -1,6 +1,6 @@
 {{global}}
 
-## Flow Network Decisions
+## Flow Harness Decisions
 
 ### Flow Platform POC — Architecture Decisions
 

--- a/.jarvis/context/docs/personal-context-protocol.md
+++ b/.jarvis/context/docs/personal-context-protocol.md
@@ -1,7 +1,7 @@
 # Personal Context Protocol
 
 How personal (per-contributor) context is managed alongside shared (git-tracked)
-project context in the Flow Network workspace.
+project context in the Flow Harness workspace.
 
 ## Principle
 

--- a/.jarvis/context/projects.md
+++ b/.jarvis/context/projects.md
@@ -1,6 +1,6 @@
 {{global}}
 
-## Flow Network Projects (Workspace)
+## Flow Harness Projects (Workspace)
 
 ### Flow Platform — POC (Active Primary)
 **Location:** `Focus/Flow/`

--- a/.jarvis/context/roadmap.md
+++ b/.jarvis/context/roadmap.md
@@ -1,6 +1,6 @@
 {{global}}
 
-# Flow Network Roadmap
+# Flow Harness Roadmap
 
 ## Current Direction
 

--- a/.jarvis/context/status.md
+++ b/.jarvis/context/status.md
@@ -1,6 +1,6 @@
 {{global}}
 
-# Flow Network Status
+# Flow Harness Status
 
 ## Active Primary Work
 

--- a/.jarvis/context/team.md
+++ b/.jarvis/context/team.md
@@ -1,6 +1,6 @@
 {{global}}
 
-# Flow Network Team
+# Flow Harness Team
 
 ## Ownership Map
 

--- a/.jarvis/context/technical-debt.md
+++ b/.jarvis/context/technical-debt.md
@@ -1,4 +1,4 @@
-# Technical Debt Register — Flow Network
+# Technical Debt Register — Flow Harness
 
 Project-level debt tracker. Every item follows the standard in `docs/standards/technical-debt-tracking-standard.md`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Flow Network — Agent Instructions
+# Flow Harness — Agent Instructions
 
 ## Workspace Structure
 

--- a/Jarvis/README.md
+++ b/Jarvis/README.md
@@ -21,7 +21,7 @@ A CLI tool for task scheduling and journaling that integrates with [AnyType](htt
 ### Installed CLI from this workspace (recommended)
 
 ```bash
-# From the Flow Network workspace root
+# From the Flow Harness workspace root
 uv tool install --force ./Jarvis
 
 # Run the installed CLI

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Flow Network
+# Flow Harness
 
-Flow Network is a reusable agent harness for software projects.
+Flow Harness is a reusable agent harness for software projects.
 
 It gives any repository a working AI operating layer with:
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "flow-harness",
   "private": true,
-  "description": "Flow Network — agent harness for any project",
+  "description": "Flow Harness — agent harness for any project",
   "scripts": {
     "setup": "node scripts/setup-local.mjs",
     "skills:validate": "node scripts/flow/validate-skills.mjs",

--- a/scripts/setup-local.mjs
+++ b/scripts/setup-local.mjs
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
 /**
- * Flow Network — Local setup wizard
+ * Flow Harness — Local setup wizard
  *
  * Creates personal context files, verifies Jarvis CLI, and registers skills.
- * Adapted from Accelerate Africa's setup-local.mjs for the Flow Network workspace.
+ * Adapted from Accelerate Africa's setup-local.mjs for the Flow Harness workspace.
  *
  * Usage:
  *   pnpm setup              # interactive wizard
@@ -204,7 +204,7 @@ const printSummary = async () => {
 // ---------------------------------------------------------------------------
 
 const main = async () => {
-  console.log("Flow Network — Local Setup\n");
+  console.log("Flow Harness — Local Setup\n");
 
   await ensureContextDirs();
   await setupLocalMd();

--- a/tools/flow-install/lib/scripts.mjs
+++ b/tools/flow-install/lib/scripts.mjs
@@ -137,7 +137,7 @@ export const patchPackageJson = async (projectRoot, { dryRun = false, scriptsDir
 };
 
 // ---------------------------------------------------------------------------
-// Script generators (fallback if Flow Network scripts/ not available)
+// Script generators (fallback if Flow Harness scripts/ not available)
 // ---------------------------------------------------------------------------
 
 function generateRegisterSkills() {


### PR DESCRIPTION
## Summary

- **Rename Flow Network → Flow Harness** across all project files, plugin IDs, marketplace names, GitHub URLs, scope IDs, and install paths
- **Standardized cleanup system**: registry-based `cleanup.mjs` with 7 declarative tasks including legacy `flow-network` → `flow-harness` migration
- **Context-sync v0.4.0**: issue-flow awareness with auto-detection, target branch override, commit enrichment, interactive state file conflict resolution
- **tmux-agent-launcher v0.1.3**: runner argument passthrough via `--`
- **CI fix**: removed `FLOW_EVAL_FULL_COMMUNITY=1` from harness-smoke workflow (was causing 1-5 hour CI runs)
- **Symlinks as primary discovery**: `~/.claude/skills/` symlinks are the working mechanism; marketplace plugin disabled

## Verification

- [x] `pnpm skills:validate` passes
- [x] `pnpm harness:verify` passes (0 failures)
- [x] All `flow-network` references updated to `flow-harness` (verified via grep)
- [x] All "Flow Network" product name references updated to "Flow Harness" in active files
- [x] Historical planning docs left unchanged