### PR TITLE
fix(flow): stop deleting skill symlinks + enable community skills for in-place installs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -109,10 +109,8 @@ parse_args() {
 
   if [[ "$INSTALL_MODE" == "in-place" ]]; then
     TARGET_ROOT="$(cd "$TARGET_ROOT" && pwd)"
-    if [[ "$INSTALL_COMMUNITY" == "auto" ]]; then
-      INSTALL_COMMUNITY="0"
-    fi
-  elif [[ "$INSTALL_COMMUNITY" == "auto" ]]; then
+  fi
+  if [[ "$INSTALL_COMMUNITY" == "auto" ]]; then
     INSTALL_COMMUNITY="1"
   fi
 }

--- a/scripts/flow/register-claude-skills.mjs
+++ b/scripts/flow/register-claude-skills.mjs
@@ -144,16 +144,6 @@ const run = async () => {
     if (await pathExists(perSkillPluginDir)) await fs.rm(perSkillPluginDir, { recursive: true, force: true });
   }
 
-  // Remove ~/.claude/skills/ symlinks (superseded by marketplace plugin)
-  const claudeSkillsDir = path.join(HOME, ".claude", "skills");
-  if (await pathExists(claudeSkillsDir)) {
-    const symlinks = await fs.readdir(claudeSkillsDir).catch(() => []);
-    if (symlinks.length > 0) {
-      for (const name of symlinks) await fs.rm(path.join(claudeSkillsDir, name), { recursive: true, force: true });
-      console.log("Removed " + symlinks.length + " stale symlinks from ~/.claude/skills/");
-    }
-  }
-
   console.log("Claude Code refreshed for " + skills.length + " skill(s)");
 };
 

--- a/scripts/flow/register-skills.mjs
+++ b/scripts/flow/register-skills.mjs
@@ -210,16 +210,6 @@ const registerClaude = async () => {
     if (await pathExists(perSkillPluginDir)) await fs.rm(perSkillPluginDir, { recursive: true, force: true });
   }
 
-  // Remove ~/.claude/skills/ symlinks (superseded by marketplace plugin)
-  const claudeSkillsDir = path.join(HOME, ".claude", "skills");
-  if (await pathExists(claudeSkillsDir)) {
-    const symlinks = await fs.readdir(claudeSkillsDir).catch(() => []);
-    if (symlinks.length > 0) {
-      for (const name of symlinks) await fs.rm(path.join(claudeSkillsDir, name), { recursive: true, force: true });
-      console.log("  Removed " + symlinks.length + " stale symlinks from ~/.claude/skills/");
-    }
-  }
-
   return skills.length;
 };
 

--- a/tools/flow-install/lib/scripts.mjs
+++ b/tools/flow-install/lib/scripts.mjs
@@ -353,16 +353,6 @@ const registerClaude = async () => {
     if (await pathExists(perSkillPluginDir)) await fs.rm(perSkillPluginDir, { recursive: true, force: true });
   }
 
-  // Remove ~/.claude/skills/ symlinks (superseded by marketplace plugin)
-  const claudeSkillsDir = path.join(HOME, ".claude", "skills");
-  if (await pathExists(claudeSkillsDir)) {
-    const symlinks = await fs.readdir(claudeSkillsDir).catch(() => []);
-    if (symlinks.length > 0) {
-      for (const name of symlinks) await fs.rm(path.join(claudeSkillsDir, name), { recursive: true, force: true });
-      console.log("  Removed " + symlinks.length + " stale symlinks from ~/.claude/skills/");
-    }
-  }
-
   return skills.length;
 };
 
@@ -623,16 +613,6 @@ const run = async () => {
   for (const skill of skills) {
     const perSkillPluginDir = path.join(skill.skillDir, ".claude-plugin");
     if (await pathExists(perSkillPluginDir)) await fs.rm(perSkillPluginDir, { recursive: true, force: true });
-  }
-
-  // Remove ~/.claude/skills/ symlinks (superseded by marketplace plugin)
-  const claudeSkillsDir = path.join(HOME, ".claude", "skills");
-  if (await pathExists(claudeSkillsDir)) {
-    const symlinks = await fs.readdir(claudeSkillsDir).catch(() => []);
-    if (symlinks.length > 0) {
-      for (const name of symlinks) await fs.rm(path.join(claudeSkillsDir, name), { recursive: true, force: true });
-      console.log("Removed " + symlinks.length + " stale symlinks from ~/.claude/skills/");
-    }
   }
 
   console.log("Claude Code refreshed for " + skills.length + " skill(s)");

--- a/tools/flow-install/skills/context-sync/commands/context-sync.md
+++ b/tools/flow-install/skills/context-sync/commands/context-sync.md
@@ -416,18 +416,26 @@ git stash push -u -m "$STASH_NAME"
 
 ### Step 3: Sync with the current working branch remote
 
-If the push branch already exists remotely and is not protected:
+First check if the push branch exists remotely:
+
+```bash
+git ls-remote --heads "$PUSH_REMOTE" "$PUSH_BRANCH"
+```
+
+If the push branch exists remotely and is not protected:
 
 ```bash
 git pull --rebase "$PUSH_REMOTE" "$PUSH_BRANCH"
 ```
 
-If the push branch does not exist remotely, skip this step and continue.
+If the push branch does not exist remotely (e.g., it was deleted after a PR merge), skip this step entirely and continue. The branch will be created fresh on push with `-u`.
 
 If the branch-sync step conflicts:
 - run `git rebase --abort`
-- preserve the stash if one exists
+- **immediately restore the stash** if one was created (do not leave changes stuck in stash)
 - stop before staging or pushing
+
+**Safety rule**: Steps 2 (stash), 3 (sync), and 4 (restore) must each be executed as separate operations. Never chain them in a single command — if sync fails after stashing, the stash must be restored before reporting the error.
 
 ### Step 4: Restore the stash if one was created
 


### PR DESCRIPTION
## Summary

- **Fix symlink deletion**: Registration scripts were deleting `~/.claude/skills/` symlinks (the primary discovery mechanism) during cleanup. Removed from template generators and standalone scripts (4 locations).
- **Fix community skills**: `install.sh` was skipping community skill installation for in-place installs. Now defaults to enabled for all install modes.
- **Harden context-sync push**: Added explicit remote branch existence check before sync, and safety rule requiring stash/sync/restore as separate operations.

## Verification

- [x] `pnpm harness:verify` passes
- [x] `pnpm skills:register` preserves symlinks (1293 before and after)