### PR TITLE
feat(issue-flow): phase transition validator with encoded transition table

### DIFF
--- a/tools/flow-install/skills/issue-flow/commands/issue-flow.md
+++ b/tools/flow-install/skills/issue-flow/commands/issue-flow.md
@@ -207,6 +207,62 @@ Phase 13 — PR creation and CI resolution
 Phase 14 — Final verification and acceptance
 Phase 15 — Closeout and GitHub sync
 
+## Phase Transition Validation
+
+Before advancing to any new phase, the orchestrator MUST validate the transition:
+
+### Validation Command
+
+```bash
+python3 "${AGENTS_SKILLS_ROOT}/issue-flow/scripts/issue_flow_validate_transition.py" check \
+    --state-path "${SPEC_ROOT}/<epic>/.issue-flow-state.json" \
+    --target-phase <N>
+```
+
+If the command exits non-zero, the transition is BLOCKED. Read the JSON output for the specific blocking reasons and resolve them before retrying.
+
+### Transition Table
+
+| From | To | Quality Gates Required | Human Gates Required | Artifact Commits Required | Pause Before Advance |
+|------|-----|----------------------|---------------------|--------------------------|---------------------|
+| 0 | 1 | issue_readiness_check | — | — | No |
+| 1 | 2 | brainstorm_discovery_gate | brainstorm_approval | — | No |
+| 2 | 3 | — | — | — | No |
+| **3** | **4** | **spec_gate** | **prd_approval** | **product_spec** | **YES — "start tech spec"** |
+| 4 | 5 | — | — | — | No |
+| **5** | **6** | **design_simplicity_gate** | **tech_spec_approval** | **technical_spec** | **YES — "start implementation"** |
+| 6 | 7 | — | execution_scope_approval | — | No |
+| 7 | 8 | — | — | — | No |
+| 8 | 9 | regression_coverage_gate | — | regression_spec | No |
+| 9 | 10 | generated_test_gate | — | — | No |
+| 10 | 11 | test_quality_gate | — | — | No |
+| 11 | 12 | qa_execution_gate | — | — | No |
+| 12 | 13 | implementation_simplicity_gate | — | — | No |
+| 13 | 14 | — | — | — | No |
+| **14** | **15** | **final_verification_gate** | **final_acceptance** | — | **YES — "close out"** |
+
+### Pause Protocol
+
+When a transition rule has `pause_after=true`:
+
+1. Complete all gate and artifact requirements for the current phase.
+2. Set phase status to `paused_awaiting_instruction`:
+   ```bash
+   python3 "${AGENTS_SKILLS_ROOT}/issue-flow/scripts/issue_flow_state.py" pause \
+       --state-path <path> \
+       --next-action "Await explicit user instruction to start tech spec"
+   ```
+3. Report the pause to the user with the exact trigger needed.
+4. DO NOT advance until the user explicitly provides the trigger instruction.
+
+### Hard Invariants
+
+1. Never advance phase while required human gates are pending.
+2. Never start tech-spec while `prd_approval != passed`.
+3. Never start tech-spec before PRD artifact commit-and-link is complete.
+4. Never auto-start any phase marked with `pause_after` — always wait for explicit user instruction.
+5. After artifact commit-and-link at a pause point, set `next_action` to describe what the user must say.
+
 ## Phase Rules
 
 ### Phase 0 — Intake, readiness check, and clarification recovery
@@ -261,6 +317,7 @@ Phase 15 — Closeout and GitHub sync
 - Human approval should confirm both delivery clarity and strategic fit for product- or workflow-shaping issues.
 - Stop for human approval before tech spec starts.
 - After the user approves `prd_approval`, execute the **Artifact Commit-and-Link** procedure for `product_spec.md` (artifact_key=`product_spec`, artifact_label="Product Spec (PRD)").
+- After artifact commit-and-link completes, run the **Pause Protocol**: set `phase.status` to `paused_awaiting_instruction` with `next_action` = "Await explicit user instruction to start tech spec." Report the pause and stop. Do NOT proceed to Phase 4 until the user explicitly says to start tech spec.
 - Update the state file with PRD review artifacts, `spec_gate` status, human approval status, artifact commit-and-link results, and `next_action`.
 
 ### Phase 4 — Tech spec
@@ -275,6 +332,7 @@ Phase 15 — Closeout and GitHub sync
 - Block advancement if the design is over-engineered, unjustifiably abstract, or poorly aligned with repo architecture.
 - Stop for human approval before implementation begins.
 - After the user approves `tech_spec_approval`, execute the **Artifact Commit-and-Link** procedure for `technical_spec.md` (artifact_key=`technical_spec`, artifact_label="Technical Spec").
+- After artifact commit-and-link completes, run the **Pause Protocol**: set `phase.status` to `paused_awaiting_instruction` with `next_action` = "Await explicit user instruction to start implementation planning." Report the pause and stop. Do NOT proceed to Phase 6 until the user explicitly says to start.
 - Update the state file with tech-spec review artifacts, `design_simplicity_gate`, human approval status, artifact commit-and-link results, and `next_action`.
 
 ### Phase 6 — Execution scope confirmation

--- a/tools/flow-install/skills/issue-flow/manifest.yaml
+++ b/tools/flow-install/skills/issue-flow/manifest.yaml
@@ -1,6 +1,6 @@
 name: issue-flow
 type: opencode
-version: 0.3.1
+version: 0.4.0
 owner: julian
 status: experimental
 blast_radius: high

--- a/tools/flow-install/skills/issue-flow/scripts/issue_flow_state.py
+++ b/tools/flow-install/skills/issue-flow/scripts/issue_flow_state.py
@@ -3,9 +3,12 @@
 import argparse
 import copy
 import json
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict
+
+sys.path.insert(0, str(Path(__file__).parent))
 
 
 QUALITY_GATES = {
@@ -40,7 +43,7 @@ def now_iso() -> str:
 def default_state(spec_root: str, epic_name: str, epic_path: str) -> Dict[str, Any]:
     timestamp = now_iso()
     return {
-        "version": 2,
+        "version": 3,
         "updated_at": timestamp,
         "issue": {
             "number": None,
@@ -94,6 +97,11 @@ def default_state(spec_root: str, epic_name: str, epic_path: str) -> Dict[str, A
             "qa_summary": None,
             "qa_logs": [],
             "verification_report": None,
+        },
+        "artifact_commits": {
+            "product_spec": {"committed": False, "skipped": False},
+            "technical_spec": {"committed": False, "skipped": False},
+            "regression_spec": {"committed": False, "skipped": False},
         },
         "reconciliation": {
             "last_checked_at": None,
@@ -173,6 +181,10 @@ def parse_args() -> argparse.Namespace:
     status_parser = subparsers.add_parser("status")
     status_parser.add_argument("--state-path", required=True)
 
+    pause_parser = subparsers.add_parser("pause")
+    pause_parser.add_argument("--state-path", required=True)
+    pause_parser.add_argument("--next-action", required=True)
+
     return parser.parse_args()
 
 
@@ -206,6 +218,23 @@ def command_merge(args: argparse.Namespace) -> int:
     path = Path(args.state_path)
     state = load_state(path)
     incoming = json.loads(args.json)
+
+    # Phase transition guard
+    incoming_phase_id = incoming.get("phase", {}).get("id")
+    current_phase_id = state.get("phase", {}).get("id")
+    if incoming_phase_id is not None and incoming_phase_id != current_phase_id:
+        from issue_flow_validate_transition import validate_transition
+        is_valid, reasons = validate_transition(state, incoming_phase_id)
+        if not is_valid:
+            error = {
+                "error": "transition_blocked",
+                "current_phase": current_phase_id,
+                "target_phase": incoming_phase_id,
+                "blocking_reasons": reasons,
+            }
+            print(json.dumps(error, indent=2), file=sys.stderr)
+            return 1
+
     merged = deep_merge(state, incoming)
     merged_phase = merged.get("phase", {})
     if merged_phase:
@@ -223,6 +252,17 @@ def command_status(args: argparse.Namespace) -> int:
     return 0
 
 
+def command_pause(args: argparse.Namespace) -> int:
+    path = Path(args.state_path)
+    state = load_state(path)
+    state["phase"]["status"] = "paused_awaiting_instruction"
+    state["next_action"] = args.next_action
+    append_history(state, "phase_paused", f"Paused: {args.next_action}", "issue-flow")
+    save_state(path, state)
+    print(json.dumps(state, indent=2))
+    return 0
+
+
 def main() -> int:
     args = parse_args()
     if args.command == "init":
@@ -231,6 +271,8 @@ def main() -> int:
         return command_merge(args)
     if args.command == "status":
         return command_status(args)
+    if args.command == "pause":
+        return command_pause(args)
     raise ValueError(f"Unknown command: {args.command}")
 
 

--- a/tools/flow-install/skills/issue-flow/scripts/issue_flow_validate_transition.py
+++ b/tools/flow-install/skills/issue-flow/scripts/issue_flow_validate_transition.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""
+issue-flow phase transition validator.
+
+Encodes the transition table as data and validates prerequisites
+before any phase change. Called by issue_flow_state.py command_merge
+and directly by the AI agent via CLI.
+
+Usage:
+    python3 issue_flow_validate_transition.py check --state-path <path> --target-phase <N>
+    python3 issue_flow_validate_transition.py show-rules
+"""
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+
+@dataclass
+class TransitionRule:
+    """What must be true before moving from one phase to the next."""
+    quality_gates: List[str]
+    human_gates: List[str]
+    artifact_commits: List[str]
+    pause_after: bool
+    explicit_trigger: Optional[str]
+
+
+TRANSITION_TABLE: Dict[Tuple[int, int], TransitionRule] = {
+    (0, 1): TransitionRule(
+        quality_gates=["issue_readiness_check"],
+        human_gates=[],
+        artifact_commits=[],
+        pause_after=False,
+        explicit_trigger=None,
+    ),
+    (1, 2): TransitionRule(
+        quality_gates=["brainstorm_discovery_gate"],
+        human_gates=["brainstorm_approval"],
+        artifact_commits=[],
+        pause_after=False,
+        explicit_trigger=None,
+    ),
+    (2, 3): TransitionRule(
+        quality_gates=[],
+        human_gates=[],
+        artifact_commits=[],
+        pause_after=False,
+        explicit_trigger=None,
+    ),
+    (3, 4): TransitionRule(
+        quality_gates=["spec_gate"],
+        human_gates=["prd_approval"],
+        artifact_commits=["product_spec"],
+        pause_after=True,
+        explicit_trigger="User explicitly says to start tech spec",
+    ),
+    (4, 5): TransitionRule(
+        quality_gates=[],
+        human_gates=[],
+        artifact_commits=[],
+        pause_after=False,
+        explicit_trigger=None,
+    ),
+    (5, 6): TransitionRule(
+        quality_gates=["design_simplicity_gate"],
+        human_gates=["tech_spec_approval"],
+        artifact_commits=["technical_spec"],
+        pause_after=True,
+        explicit_trigger="User explicitly says to start implementation planning",
+    ),
+    (6, 7): TransitionRule(
+        quality_gates=[],
+        human_gates=["execution_scope_approval"],
+        artifact_commits=[],
+        pause_after=False,
+        explicit_trigger=None,
+    ),
+    (7, 8): TransitionRule(
+        quality_gates=[],
+        human_gates=[],
+        artifact_commits=[],
+        pause_after=False,
+        explicit_trigger=None,
+    ),
+    (8, 9): TransitionRule(
+        quality_gates=["regression_coverage_gate"],
+        human_gates=[],
+        artifact_commits=["regression_spec"],
+        pause_after=False,
+        explicit_trigger=None,
+    ),
+    (9, 10): TransitionRule(
+        quality_gates=["generated_test_gate"],
+        human_gates=[],
+        artifact_commits=[],
+        pause_after=False,
+        explicit_trigger=None,
+    ),
+    (10, 11): TransitionRule(
+        quality_gates=["test_quality_gate"],
+        human_gates=[],
+        artifact_commits=[],
+        pause_after=False,
+        explicit_trigger=None,
+    ),
+    (11, 12): TransitionRule(
+        quality_gates=["qa_execution_gate"],
+        human_gates=[],
+        artifact_commits=[],
+        pause_after=False,
+        explicit_trigger=None,
+    ),
+    (12, 13): TransitionRule(
+        quality_gates=["implementation_simplicity_gate"],
+        human_gates=[],
+        artifact_commits=[],
+        pause_after=False,
+        explicit_trigger=None,
+    ),
+    (13, 14): TransitionRule(
+        quality_gates=[],
+        human_gates=[],
+        artifact_commits=[],
+        pause_after=False,
+        explicit_trigger=None,
+    ),
+    (14, 15): TransitionRule(
+        quality_gates=["final_verification_gate"],
+        human_gates=["final_acceptance"],
+        artifact_commits=[],
+        pause_after=True,
+        explicit_trigger="User explicitly says to close out",
+    ),
+}
+
+
+def validate_transition(state: dict, target_phase_id: int) -> Tuple[bool, List[str]]:
+    """
+    Validate whether the state allows advancing to target_phase_id.
+    Returns (is_valid, list_of_blocking_reasons).
+    """
+    current_phase_id = state.get("phase", {}).get("id", 0)
+    current_status = state.get("phase", {}).get("status", "pending")
+
+    # No skipping phases
+    if target_phase_id > current_phase_id + 1:
+        return (False, [
+            f"Cannot skip from phase {current_phase_id} to {target_phase_id}; "
+            f"must advance one phase at a time"
+        ])
+
+    # No going backward
+    if target_phase_id <= current_phase_id:
+        return (False, [
+            f"Cannot move backward from phase {current_phase_id} to {target_phase_id}"
+        ])
+
+    key = (current_phase_id, target_phase_id)
+    rule = TRANSITION_TABLE.get(key)
+    if rule is None:
+        return (False, [f"No transition rule defined for {current_phase_id} -> {target_phase_id}"])
+
+    reasons = []
+    gates = state.get("gates", {})
+
+    # Check quality gates
+    for qg in rule.quality_gates:
+        val = gates.get("quality", {}).get(qg, "pending")
+        if val != "passed":
+            reasons.append(f"Quality gate '{qg}' is '{val}', must be 'passed'")
+
+    # Check human gates
+    for hg in rule.human_gates:
+        val = gates.get("human", {}).get(hg, "pending")
+        if val != "passed":
+            reasons.append(f"Human gate '{hg}' is '{val}', must be 'passed'")
+
+    # Check artifact commits
+    ac = state.get("artifact_commits", {})
+    for ak in rule.artifact_commits:
+        entry = ac.get(ak, {})
+        committed = entry.get("committed", False)
+        skipped = entry.get("skipped", False)
+        if not committed and not skipped:
+            reasons.append(
+                f"Artifact commit '{ak}' not completed "
+                f"(committed={committed}, skipped={skipped})"
+            )
+
+    # Check pause requirement
+    if rule.pause_after:
+        if current_status != "paused_awaiting_instruction":
+            reasons.append(
+                f"Phase {current_phase_id} requires explicit user instruction to advance. "
+                f"phase.status must be 'paused_awaiting_instruction', is '{current_status}'. "
+                f"Expected trigger: {rule.explicit_trigger}"
+            )
+
+    return (len(reasons) == 0, reasons)
+
+
+def command_check(args: argparse.Namespace) -> int:
+    path = Path(args.state_path)
+    if not path.exists():
+        print(json.dumps({"error": f"State file not found: {path}"}))
+        return 1
+
+    state = json.loads(path.read_text(encoding="utf-8"))
+    is_valid, reasons = validate_transition(state, args.target_phase)
+
+    current_phase_id = state.get("phase", {}).get("id", 0)
+    key = (current_phase_id, args.target_phase)
+    rule = TRANSITION_TABLE.get(key)
+
+    result = {
+        "valid": is_valid,
+        "current_phase": current_phase_id,
+        "target_phase": args.target_phase,
+        "blocking_reasons": reasons,
+    }
+    if rule:
+        result["rule"] = asdict(rule)
+
+    print(json.dumps(result, indent=2))
+    return 0 if is_valid else 1
+
+
+def command_show_rules(args: argparse.Namespace) -> int:
+    rules = {}
+    for (from_p, to_p), rule in sorted(TRANSITION_TABLE.items()):
+        rules[f"{from_p}->{to_p}"] = asdict(rule)
+    print(json.dumps(rules, indent=2))
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description="issue-flow phase transition validator")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    check_parser = subparsers.add_parser("check", help="Validate a phase transition")
+    check_parser.add_argument("--state-path", required=True, help="Path to .issue-flow-state.json")
+    check_parser.add_argument("--target-phase", type=int, required=True, help="Target phase ID")
+
+    subparsers.add_parser("show-rules", help="Print the full transition table")
+
+    args = parser.parse_args()
+
+    if args.command == "check":
+        sys.exit(command_check(args))
+    elif args.command == "show-rules":
+        sys.exit(command_show_rules(args))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **issue-flow v0.4.0**: Machine-checkable phase transition validator
- `issue_flow_validate_transition.py` encodes the full 15-phase transition table as data
- `command_merge` guard rejects invalid phase changes (double protection)
- New `pause` command sets `paused_awaiting_instruction` status
- Explicit pause points at Phase 3→4 (PRD→tech spec), Phase 5→6 (tech spec→implementation), Phase 14→15 (verification→closeout)
- Hard invariants: no skipping, no advancing without gates, no auto-starting paused phases

## Tested against AA issue #115

Validator correctly blocks Phase 3→4 with:
- `prd_approval` is pending
- `product_spec` artifact not committed
- Phase not in `paused_awaiting_instruction` status

## Verification

- [x] `pnpm harness:verify` passes
- [x] Validator blocks invalid transitions (tested on real state file)
- [x] `command_merge` guard rejects direct merges that skip validation