### PR TITLE
fix(flow): fix /dev/tty redirect for curl|bash interactive prompts

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -188,17 +188,17 @@ install_flow_framework() {
 
   # When running via curl | bash, stdin is the pipe not the terminal.
   # Redirect stdin from /dev/tty so interactive prompts work.
-  local stdin_redirect=""
+  local use_tty=0
   if [[ ! -t 0 ]] && [[ -e /dev/tty ]] && [[ "$FLOW_NONINTERACTIVE" != "1" ]]; then
-    stdin_redirect="</dev/tty"
+    use_tty=1
   fi
 
   if [[ "$INSTALL_MODE" == "in-place" ]]; then
     log "[info] Installing Flow framework into target repo: $TARGET_ROOT"
-    if ((${#flow_args[@]})); then
-      eval node "$FLOW_ROOT/tools/flow-install/index.mjs" "${flow_args[@]}" --target "$TARGET_ROOT" $stdin_redirect
+    if [[ "$use_tty" == "1" ]]; then
+      node "$FLOW_ROOT/tools/flow-install/index.mjs" "${flow_args[@]}" --target "$TARGET_ROOT" </dev/tty
     else
-      eval node "$FLOW_ROOT/tools/flow-install/index.mjs" --target "$TARGET_ROOT" $stdin_redirect
+      node "$FLOW_ROOT/tools/flow-install/index.mjs" "${flow_args[@]}" --target "$TARGET_ROOT"
     fi
     return
   fi
@@ -206,10 +206,10 @@ install_flow_framework() {
   log "[info] Installing Flow framework into project root"
   (
     cd "$FLOW_ROOT"
-    if ((${#flow_args[@]})); then
-      eval node tools/flow-install/index.mjs "${flow_args[@]}" $stdin_redirect
+    if [[ "$use_tty" == "1" ]]; then
+      node tools/flow-install/index.mjs "${flow_args[@]}" </dev/tty
     else
-      eval node tools/flow-install/index.mjs $stdin_redirect
+      node tools/flow-install/index.mjs "${flow_args[@]}"
     fi
   )
 }


### PR DESCRIPTION
## Summary

- Fix the `/dev/tty` stdin redirect in `install.sh` so interactive prompts (like the autoflow CI question) actually wait for user input when running via `curl | bash`
- Replace fragile `eval` + variable approach with direct `</dev/tty` redirection on the node command
- Fixes path-with-spaces bug (e.g., "Accelerate Africa") caused by `eval`

## Test plan

- [ ] `curl -fsSL .../install.sh | bash -s -- --here` shows autoflow prompt and waits for input
- [ ] Paths with spaces work correctly
- [ ] `--yes` mode still skips prompts silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)