### PR TITLE
fix(flow-install): make life-orchestrator cron runs use real project …

### DIFF
--- a/.jarvis/context/AGENTS.md
+++ b/.jarvis/context/AGENTS.md
@@ -9,16 +9,15 @@ This file contains Harnessy's installed agent protocol for this repository.
 <!-- flow-context:start -->
 ## Harnessy Protocol
 
-This repo is Harnessy-managed. Use this file as the canonical agent protocol for
-the installed project.
+This repo is Harnessy-managed. Use this file as the canonical Harnessy agent protocol for the installed project.
 
 ### Session Start
 
 1. Read `.jarvis/context/README.md`
-2. Check `.jarvis/context/skills/_catalog.md` for installed project catalog entries
-3. Read `.jarvis/context/scopes/_scopes.yaml` when you need memory scope structure
-4. For implementation work, read `.jarvis/context/docs/standards/development-guidance.md`
-5. For contribution and maintenance workflows, read `.jarvis/context/docs/contribution-protocol.md`
+2. Load context in order: `status.md` -> `roadmap.md` -> `team.md` -> `technical-debt.md`
+3. For ideation, issue intake, PRD, roadmap, and architecture tradeoff work, read `.jarvis/context/docs/strategy/README.md` when it exists, then load the relevant strategy docs it points to
+4. Treat `projects.md` and `decisions.md` as optional supporting docs when present
+5. Check `.jarvis/context/skills/_catalog.md` for project catalog entries
 6. Prefer deeper sub-project context when working inside a nested app with its own `.jarvis/context/`
 
 ### Skills
@@ -26,17 +25,19 @@ the installed project.
 - Global skills live in `~/.agents/skills/`
 - Project-local skills live in `.agents/skills/` when present
 - Run `pnpm skills:register` after adding or updating project-local skills
-- Run `pnpm harness:verify` to confirm Harnessy, OpenCode, and Claude parity
+- Run `pnpm harness:verify` to confirm Harnessy, community, OpenCode, and Claude parity
 
 ### Context Vault
 
 - Canonical context root: `.jarvis/context/`
+- Standard strategy folder: `.jarvis/context/docs/strategy/`
 - Memory scope registry: `.jarvis/context/scopes/_scopes.yaml`
+- Technical debt register: `.jarvis/context/technical-debt.md`
 - Template token `{{global}}` is Jarvis templating; treat it as a no-op in raw files
 
 ### Conventions
 
 - Never commit `.env` files; use `.env.example`
 - Personal context belongs in `.jarvis/context/private/<username>/`
-- Keep durable project guidance in tracked docs, not only in chat or TODO comments
+- Keep debt tracked in the debt registers, not only in chat or TODO comments
 <!-- flow-context:end -->

--- a/harnessy.lock.json
+++ b/harnessy.lock.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "timestamp": "2026-04-19T23:34:48.131Z",
+  "timestamp": "2026-04-24T06:22:33.672Z",
   "project": "harnessy",
   "monorepo": null,
   "apps": [],
@@ -1329,7 +1329,7 @@
   },
   "contextAgents": {
     "version": "1.1.0",
-    "templateHash": "9782b224e6c0509f56f20f26ad207d4a636552d2d5b55748ed9593e55bdfcd69",
+    "templateHash": "eac04478428c8973c608d4f9128a5c4bd8ee83ef0e12c0333b2be3da5f517215",
     "status": "current",
     "path": ".jarvis/context/AGENTS.md"
   },

--- a/tools/flow-install/scripts/flow-cron
+++ b/tools/flow-install/scripts/flow-cron
@@ -306,6 +306,23 @@ def install_launchd(enabled: list[dict], project_dir: str) -> None:
     LAUNCHD_DIR.mkdir(parents=True, exist_ok=True)
     CRON_STATE_DIR.mkdir(parents=True, exist_ok=True)
 
+    desired_plists = {
+        launchd_plist_path(s["skill"], s["name"]) for s in enabled
+    }
+
+    # Prune stale jobs first so install remains a true reflection of enabled state.
+    for existing_plist in sorted(LAUNCHD_DIR.glob(f"{LAUNCHD_PREFIX}.*.plist")):
+        if existing_plist in desired_plists:
+            continue
+        subprocess.run(
+            ["launchctl", "bootout", f"gui/{os.getuid()}", str(existing_plist)],
+            capture_output=True,
+        )
+        try:
+            existing_plist.unlink()
+        except FileNotFoundError:
+            pass
+
     for s in enabled:
         label = launchd_label(s["skill"], s["name"])
         plist_path = launchd_plist_path(s["skill"], s["name"])

--- a/tools/flow-install/skills/life-orchestrator/manifest.yaml
+++ b/tools/flow-install/skills/life-orchestrator/manifest.yaml
@@ -1,6 +1,6 @@
 name: life-orchestrator
 type: opencode
-version: 0.1.0
+version: 0.1.2
 owner: julian
 status: experimental
 blast_radius: medium
@@ -32,14 +32,14 @@ state:
 schedule:
   - name: daily-brief
     cron: "30 5 * * *"
-    type: prompt
-    command: "/life daily"
+    type: shell
+    command: 'python3 "${AGENTS_SKILLS_ROOT:-$HOME/.agents/skills}/life-orchestrator/scripts/daily-brief"'
     description: "Daily focus brief at 05:30 (chief-of-staff synthesis)"
     enabled: false
   - name: weekly-plan
     cron: "0 18 * * 0"
-    type: prompt
-    command: "/life weekly"
+    type: shell
+    command: 'bash "${AGENTS_SKILLS_ROOT:-$HOME/.agents/skills}/life-orchestrator/scripts/weekly-plan"'
     description: "Weekly plan, Sundays 18:00 (anchors next week's briefs)"
     enabled: false
   - name: monthly-review

--- a/tools/flow-install/skills/life-orchestrator/scripts/collect-state
+++ b/tools/flow-install/skills/life-orchestrator/scripts/collect-state
@@ -17,12 +17,32 @@ import sys
 
 # ── Paths ────────────────────────────────────────────────────────────────────
 
-PROJECT_ROOT = os.environ.get(
-    "FLOW_PROJECT_ROOT",
-    os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(
-        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    ))))
-)
+def detect_project_root():
+    """Resolve the active Harnessy project root.
+
+    Installed global skill scripts live under `~/.agents/skills`, so deriving the
+    project root from `__file__` points at the global skill directory rather than
+    the repo the scheduler `cd`'d into. Prefer an explicit env var, then the
+    current working tree, and only fall back to the current directory.
+    """
+    env_root = os.environ.get("FLOW_PROJECT_ROOT")
+    if env_root:
+        return env_root
+
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, timeout=5, cwd=os.getcwd(),
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+
+    return os.getcwd()
+
+
+PROJECT_ROOT = detect_project_root()
 
 _USERNAME = os.environ.get("FLOW_USER", os.environ.get("USER", "default"))
 PRIVATE_DIR = os.path.join(PROJECT_ROOT, ".jarvis", "context", "private", _USERNAME)

--- a/tools/flow-install/skills/life-orchestrator/scripts/daily-brief
+++ b/tools/flow-install/skills/life-orchestrator/scripts/daily-brief
@@ -22,12 +22,32 @@ COLLECT_STATE = os.path.join(SCRIPTS_DIR, "collect-state")
 NOTIFY = os.path.join(SCRIPTS_DIR, "notify")
 AGENTS_LIFE_DIR = os.path.expanduser("~/.agents/life")
 
-PROJECT_ROOT = os.environ.get(
-    "FLOW_PROJECT_ROOT",
-    os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(
-        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    ))))
-)
+def detect_project_root():
+    """Resolve the active Harnessy project root.
+
+    When the skill is installed globally, `__file__` lives under
+    `~/.agents/skills/...`, not inside the active repo. Scheduled runs `cd` into
+    the target project before invoking this script, so prefer the environment or
+    the current git worktree.
+    """
+    env_root = os.environ.get("FLOW_PROJECT_ROOT")
+    if env_root:
+        return env_root
+
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, timeout=5, cwd=os.getcwd(),
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+
+    return os.getcwd()
+
+
+PROJECT_ROOT = detect_project_root()
 _USERNAME = os.environ.get("FLOW_USER", os.environ.get("USER", "default"))
 _USER_PROJECT_PREFIX = f"_{_USERNAME}/"
 

--- a/tools/flow-install/skills/life-orchestrator/scripts/weekly-plan
+++ b/tools/flow-install/skills/life-orchestrator/scripts/weekly-plan
@@ -17,7 +17,11 @@ set -u
 
 SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILL_DIR="$(cd "$SCRIPTS_DIR/.." && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPTS_DIR/../../../../.." && pwd)"
+if [ -n "${FLOW_PROJECT_ROOT:-}" ]; then
+    PROJECT_ROOT="$FLOW_PROJECT_ROOT"
+else
+    PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+fi
 
 YEAR=$(date +%Y)
 MONTH=$(date +%b)


### PR DESCRIPTION
…state

Run life-orchestrator scheduled jobs through the deterministic daily and weekly scripts instead of slash-command prompts so launchd can produce real outputs. Resolve project roots from the active git worktree for globally installed skills, and prune stale disabled launchd jobs during cron install to keep local schedule state in sync.

Co-Authored-By: Claude <noreply@anthropic.com>

If you want one message that covers the broader recent burst, including the contributor protocol work too, I’d use: feat(harnessy): standardize contributor flow and harden life orchestration Clarify the public contributor path with a shared-skill promotion packet and Harnessy core terminology, then harden life-orchestrator scheduling so globally installed jobs resolve the active project correctly and produce real daily briefs. This keeps contributor workflows clearer and local automation more trustworthy.

Co-Authored-By: Claude <noreply@anthropic.com>