### PR TITLE
feat(ratchet): add --verbose flag to score subcommand

### DIFF
--- a/tools/flow-install/skills/_shared/ratchet.py
+++ b/tools/flow-install/skills/_shared/ratchet.py
@@ -345,6 +345,36 @@ def command_score(args: argparse.Namespace) -> int:
             print(f"  h (human intervention):{variables['h']:.2f}")
             print(f"  c (cost):             {variables['c']:.2f}")
 
+        if args.verbose:
+            print()
+            print("  Breakdown (variable | raw | weight | weighted contribution):")
+            exp = DEFAULT_CONFIG["layer_1" if layer == 1 else "layer_2"]
+            # base values mirror compute_score: (1 - x) for r/h/c, floored at 1e-10
+            inverted = {"r", "h", "c"}
+            labels = {
+                "f": "final success",
+                "p": "first-pass",
+                "q": "output quality",
+                "r": "refinement burden",
+                "h": "human intervention",
+                "c": "cost",
+            }
+            for name in exp:
+                raw = variables[name]
+                base = max((1.0 - raw) if name in inverted else raw, 1e-10)
+                weight = exp[name]
+                contribution = base ** weight
+                print(
+                    f"    {name} ({labels[name]}): raw={raw:.4f}  "
+                    f"weight={weight:.2f}  contribution={contribution:.4f}"
+                )
+            raw_block = variables.get("raw", {})
+            if raw_block:
+                print()
+                print("  Raw aggregates:")
+                for k, v in raw_block.items():
+                    print(f"    {k}: {v}")
+
     return 0
 
 
@@ -626,6 +656,11 @@ def parse_args() -> argparse.Namespace:
     sc.add_argument("--skill", required=True)
     sc.add_argument("--layer", type=int, default=1, choices=[1, 2])
     sc.add_argument("--json", action="store_true")
+    sc.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print a per-variable breakdown (raw value, weight, weighted contribution).",
+    )
 
     # gates
     gt = subparsers.add_parser("gates", help="Check hard constraint gates")


### PR DESCRIPTION
## Summary

Adds a `--verbose` flag to `ratchet.py score` that prints a per-variable
breakdown of the composite metric.

`score` already prints `f/p/q/r` by default, so `--verbose` surfaces what
isn't shown today: each variable's **weight** (the layer's exponent) and its
**weighted contribution** (`base ** exponent`), plus the raw aggregate counts
that were previously only available via `--json`.

Closes #26

## Changes

**`tools/flow-install/skills/_shared/ratchet.py`** (display-only, +35/-0):

- `parse_args()` — added `--verbose` to the `score` subparser (optional,
  `action="store_true"`).
- `command_score()` — when `--verbose` is set (and not `--json`), print a
  breakdown: `variable | raw | weight | weighted contribution` for each active
  variable (f/p/q/r, plus h/c at layer 2), followed by the raw aggregates.

No change to the metric, `compute_score`, JSON output, or any other
subcommand. The breakdown reuses the in-file `DEFAULT_CONFIG` exponents and
mirrors `compute_score`'s `(1 - x)` inversion for r/h/c, so the printed
contributions multiply back to the reported score.

## Acceptance criteria

- [x] `score --skill issue-flow --verbose` prints per-variable details
- [x] Flag is optional and does not affect normal output when omitted
- [x] Output includes variable name, raw value, weight, and weighted contribution

## Testing

This repo has no pytest gate for `ratchet.py`, so I verified by runtime output
(same approach as #45):

```bash
python3 -c "import ast; ast.parse(open('tools/flow-install/skills/_shared/ratchet.py').read())"  # OK
python3 ratchet.py score --skill issue-flow --verbose            # breakdown renders (layer 1)
python3 ratchet.py score --skill issue-flow --layer 2 --verbose  # includes h, c
python3 ratchet.py score --skill issue-flow --verbose --json     # --json wins, no breakdown
python3 ratchet.py score --skill issue-flow                      # byte-identical to main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--verbose` flag to the score command, providing detailed breakdowns of individual metrics, their weights, and weighted contributions for enhanced insights into scoring results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->