### PR TITLE
fix(meetings): proper Obsidian notes + plain-text participants (#50, #51, #52)

### DIFF
--- a/jarvis-cli/src/jarvis/cli.py
+++ b/jarvis-cli/src/jarvis/cli.py
@@ -1,6 +1,7 @@
 """CLI interface for Jarvis task scheduler."""
 
 import os
+import sys
 from datetime import UTC, date, datetime, timedelta
 
 import click
@@ -37,6 +38,26 @@ from jarvis.state import (
 )
 
 console = Console()
+
+
+def _ensure_utf8_console() -> None:
+    """Make CLI output able to encode unicode glyphs (✓, →, …).
+
+    On Windows the default console codepage (e.g. cp1252) raises
+    UnicodeEncodeError when these are printed; reconfigure stdout/stderr to
+    UTF-8 with a safe fallback so commands don't crash on success messages.
+    """
+
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is not None:
+            try:
+                reconfigure(encoding="utf-8", errors="replace")
+            except (ValueError, OSError):
+                pass
+
+
+_ensure_utf8_console()
 
 
 def get_adapter(backend: str | None = None) -> KnowledgeBaseAdapter:

--- a/jarvis-cli/src/jarvis/meetings/cli.py
+++ b/jarvis-cli/src/jarvis/meetings/cli.py
@@ -47,7 +47,7 @@ _WEBHOOK_TRIGGER_CHOICES = [
     "my_shared_with_team_recordings",
     "shared_team_recordings",
 ]
-_DESTINATION_CHOICES = ["private-context", "wiki", "journal", "memory"]
+_DESTINATION_CHOICES = ["private-context", "wiki", "obsidian", "journal", "memory"]
 _JOURNAL_SPACE_HELP = (
     "Backend space/workspace ID for the journal destination; overrides the backend default"
 )
@@ -132,6 +132,8 @@ def fathom_webhook_group() -> None:
     help="Destination to write to (defaults to private-context)",
 )
 @click.option("--wiki-domain", default=None, help="Wiki domain when using the wiki destination")
+@click.option("--vault", default=None, help="Obsidian vault path for the obsidian destination")
+@click.option("--folder", default="Meetings", help="Vault subfolder for the obsidian destination")
 @click.option("--journal-space", "journal_space_id", default=None, help=_JOURNAL_SPACE_HELP)
 @click.option("--enrich-ai/--no-enrich-ai", default=True, help="Use AI to fill missing sections")
 @click.option("--json", "as_json", is_flag=True, help="Emit the result as JSON")
@@ -145,6 +147,8 @@ def ingest_command(
     tags: tuple[str, ...],
     destinations: tuple[str, ...],
     wiki_domain: str | None,
+    vault: str | None,
+    folder: str,
     journal_space_id: str | None,
     enrich_ai: bool,
     as_json: bool,
@@ -165,6 +169,8 @@ def ingest_command(
             tags=list(tags) or None,
             destinations=list(destinations),
             wiki_domain=wiki_domain,
+            vault=vault,
+            folder=folder,
             journal_space_id=journal_space_id,
             enrich_ai=enrich_ai,
         )

--- a/jarvis-cli/src/jarvis/meetings/cli.py
+++ b/jarvis-cli/src/jarvis/meetings/cli.py
@@ -47,7 +47,10 @@ _WEBHOOK_TRIGGER_CHOICES = [
     "my_shared_with_team_recordings",
     "shared_team_recordings",
 ]
-_DESTINATION_CHOICES = ["private-context", "wiki", "obsidian", "journal", "memory"]
+_DESTINATION_CHOICES = ["private-context", "wiki", "journal", "memory"]
+# Only `meeting ingest` accepts --vault/--folder, so the obsidian destination is
+# exposed only there; other commands keep the restricted set.
+_INGEST_DESTINATION_CHOICES = [*_DESTINATION_CHOICES, "obsidian"]
 _JOURNAL_SPACE_HELP = (
     "Backend space/workspace ID for the journal destination; overrides the backend default"
 )
@@ -128,7 +131,7 @@ def fathom_webhook_group() -> None:
     "--dest",
     "destinations",
     multiple=True,
-    type=click.Choice(_DESTINATION_CHOICES),
+    type=click.Choice(_INGEST_DESTINATION_CHOICES),
     help="Destination to write to (defaults to private-context)",
 )
 @click.option("--wiki-domain", default=None, help="Wiki domain when using the wiki destination")

--- a/jarvis-cli/src/jarvis/meetings/parser.py
+++ b/jarvis-cli/src/jarvis/meetings/parser.py
@@ -48,6 +48,7 @@ def parse_meeting_document(
         infer_meeting_date(metadata.get("date", ""), source.markdown, source.title)
         or date.today()
     )
+    inline_fields = extract_inline_fields(preamble)
     participants = []
     for heading in _PARTICIPANT_HEADINGS:
         body = sections.get(heading)
@@ -56,6 +57,11 @@ def parse_meeting_document(
             break
     if not participants and metadata.get("participants"):
         participants = extract_people(metadata["participants"])
+    if not participants:
+        for field in _PARTICIPANT_HEADINGS:
+            if inline_fields.get(field):
+                participants = extract_people(inline_fields[field])
+                break
 
     summary = first_section(sections, _SUMMARY_HEADINGS)
     detailed_summary = first_section(sections, _DETAILED_SUMMARY_HEADINGS)
@@ -167,6 +173,25 @@ def extract_metadata(body: str) -> dict[str, str]:
     return metadata
 
 
+def extract_inline_fields(text: str) -> dict[str, str]:
+    """Extract bare `Key: Value` lines (no bullet) from a preamble block.
+
+    Plain-text and manual meeting notes often place fields like
+    ``Participants: A, B`` directly under the title rather than inside a
+    ``## Metadata`` section. Those would otherwise be dropped.
+    """
+
+    fields: dict[str, str] = {}
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith(("-", "*", "+", "#", ">")):
+            continue
+        match = re.match(r"^([A-Za-z][\w ]{0,40}):\s+(.+)$", line)
+        if match:
+            fields.setdefault(normalize_heading(match.group(1)), match.group(2).strip())
+    return fields
+
+
 def extract_transcript_block(markdown: str) -> str:
     """Extract likely transcript lines from markdown when no section exists."""
 
@@ -274,6 +299,75 @@ def render_meeting_markdown(meeting: MeetingRecord) -> str:
     add_section("Key Decisions", meeting.decisions)
     if not has_visible_action_heading(meeting.detailed_summary):
         add_section("Next Steps", meeting.action_items)
+    add_section("Open Questions", meeting.open_questions)
+    return "\n".join(lines).strip() + "\n"
+
+
+def _yaml_str(value: str) -> str:
+    """Quote a scalar for YAML frontmatter only when required."""
+
+    value = value.replace("\n", " ").strip()
+    if value and value[0] not in "-?:" and not re.search(r'[:#\[\]{}",&*!|>%@`]', value):
+        return value
+    return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def _obsidian_tag(value: str) -> str:
+    """Normalize a label into an Obsidian-safe tag (no spaces)."""
+
+    return re.sub(r"[^A-Za-z0-9/_-]+", "-", value.strip().lower()).strip("-")
+
+
+def render_obsidian_meeting_markdown(meeting: MeetingRecord) -> str:
+    """Render a meeting as a first-class Obsidian note.
+
+    Emits YAML frontmatter (so Obsidian shows Properties), a ``#meeting`` tag,
+    action items as ``- [ ]`` checkboxes, and ``[[wikilinks]]`` for participants
+    so the note participates in graph view, backlinks, and the tasks view.
+    """
+
+    tags = ["meeting"]
+    for label in ([meeting.project] if meeting.project else []) + list(meeting.tags):
+        slug = _obsidian_tag(label)
+        if slug and slug not in tags:
+            tags.append(slug)
+
+    lines = [
+        "---",
+        f"title: {_yaml_str(meeting.title)}",
+        f"date: {meeting.meeting_date.isoformat()}",
+        "type: meeting",
+    ]
+    if meeting.participants:
+        lines.append("participants:")
+        lines.extend(f"  - {_yaml_str(person)}" for person in meeting.participants)
+    lines.append("tags:")
+    lines.extend(f"  - {tag}" for tag in tags)
+    if meeting.source_ref:
+        lines.append(f"source: {_yaml_str(meeting.source_ref)}")
+    lines.extend(["---", "", f"# {meeting.title}", ""])
+
+    callout = f"> [!info] Meeting\n> **Date:** {meeting.meeting_date.isoformat()}"
+    if meeting.participants:
+        people = ", ".join(f"[[{person}]]" for person in meeting.participants)
+        callout += f" · **People:** {people}"
+    lines.append(callout)
+
+    def add_section(title: str, body: str | list[str], *, checkbox: bool = False) -> None:
+        if not body:
+            return
+        lines.extend(["", f"## {title}", ""])
+        if isinstance(body, list):
+            prefix = "- [ ] " if checkbox else "- "
+            lines.extend(f"{prefix}{item}" for item in body)
+        else:
+            lines.append(body.strip())
+
+    add_section("Executive Summary", meeting.summary)
+    add_section("Detailed Summary", demote_markdown_headings(meeting.detailed_summary))
+    add_section("Key Decisions", meeting.decisions)
+    if not has_visible_action_heading(meeting.detailed_summary):
+        add_section("Action Items", meeting.action_items, checkbox=True)
     add_section("Open Questions", meeting.open_questions)
     return "\n".join(lines).strip() + "\n"
 

--- a/jarvis-cli/src/jarvis/meetings/parser.py
+++ b/jarvis-cli/src/jarvis/meetings/parser.py
@@ -358,8 +358,12 @@ def render_obsidian_meeting_markdown(meeting: MeetingRecord) -> str:
             return
         lines.extend(["", f"## {title}", ""])
         if isinstance(body, list):
-            prefix = "- [ ] " if checkbox else "- "
-            lines.extend(f"{prefix}{item}" for item in body)
+            if checkbox:
+                for item in body:
+                    cleaned = re.sub(r"^\[[ xX]\]\s*", "", item)
+                    lines.append(f"- [ ] {cleaned}")
+            else:
+                lines.extend(f"- {item}" for item in body)
         else:
             lines.append(body.strip())
 

--- a/jarvis-cli/src/jarvis/meetings/service.py
+++ b/jarvis-cli/src/jarvis/meetings/service.py
@@ -18,7 +18,12 @@ from jarvis.wiki.parser import slug_from_title
 
 from .fathom import FathomClient, parse_fathom_json_text, parse_fathom_payload
 from .models import MeetingIngestResult, MeetingRecord
-from .parser import meeting_filename, parse_meeting_document, render_meeting_markdown
+from .parser import (
+    meeting_filename,
+    parse_meeting_document,
+    render_meeting_markdown,
+    render_obsidian_meeting_markdown,
+)
 from .webhook import list_inbox_files, load_archived_payload, move_inbox_file
 
 console = Console()
@@ -40,6 +45,8 @@ def ingest_meeting(
     destinations: list[str] | None = None,
     wiki_domain: str | None = None,
     journal_space_id: str | None = None,
+    vault: str | None = None,
+    folder: str = "Meetings",
     enrich_ai: bool = True,
 ) -> MeetingIngestResult:
     """Ingest a meeting transcript-like source into one or more destinations."""
@@ -62,6 +69,8 @@ def ingest_meeting(
         wiki_domain=wiki_domain,
         backend=backend,
         journal_space_id=journal_space_id,
+        vault=vault,
+        folder=folder,
     )
 
 
@@ -331,6 +340,8 @@ def write_meeting_record(
     wiki_domain: str | None = None,
     backend: str | None = None,
     journal_space_id: str | None = None,
+    vault: str | None = None,
+    folder: str = "Meetings",
 ) -> MeetingIngestResult:
     """Write a normalized meeting record to one or more destinations."""
 
@@ -346,6 +357,11 @@ def write_meeting_record(
             if not wiki_domain:
                 raise ValueError("--wiki-domain is required when using the wiki destination")
             path = write_wiki_meeting(wiki_domain, meeting, rendered)
+            result.written_paths.append(str(path))
+        elif destination == "obsidian":
+            if not vault:
+                raise ValueError("--vault is required when using the obsidian destination")
+            path = write_obsidian_meeting(vault, meeting, folder=folder)
             result.written_paths.append(str(path))
         elif destination == "journal":
             entry = write_journal_entry(
@@ -505,6 +521,25 @@ def write_wiki_meeting(domain: str, meeting: MeetingRecord, rendered: str) -> Pa
         raise FileNotFoundError(f"Wiki domain not found: {domain}")
     notes_dir = domain_root / "raw" / "notes"
     notes_dir.mkdir(parents=True, exist_ok=True)
+    path = unique_path(notes_dir / meeting_filename(meeting))
+    path.write_text(rendered, encoding="utf-8")
+    return path
+
+
+def write_obsidian_meeting(vault: str, meeting: MeetingRecord, *, folder: str = "Meetings") -> Path:
+    """Write a finished, Obsidian-formatted meeting note directly into a vault.
+
+    Unlike the ``wiki`` destination (which stages raw input for ``wiki compile``),
+    this writes a publish-ready note with YAML frontmatter, tags, checkboxes, and
+    wikilinks straight into the user's real Obsidian vault.
+    """
+
+    vault_root = Path(vault).expanduser()
+    if not vault_root.exists():
+        raise FileNotFoundError(f"Obsidian vault not found: {vault_root}")
+    notes_dir = vault_root / folder if folder else vault_root
+    notes_dir.mkdir(parents=True, exist_ok=True)
+    rendered = render_obsidian_meeting_markdown(meeting)
     path = unique_path(notes_dir / meeting_filename(meeting))
     path.write_text(rendered, encoding="utf-8")
     return path

--- a/jarvis-cli/src/jarvis/meetings/service.py
+++ b/jarvis-cli/src/jarvis/meetings/service.py
@@ -537,7 +537,10 @@ def write_obsidian_meeting(vault: str, meeting: MeetingRecord, *, folder: str = 
     vault_root = Path(vault).expanduser()
     if not vault_root.exists():
         raise FileNotFoundError(f"Obsidian vault not found: {vault_root}")
-    notes_dir = vault_root / folder if folder else vault_root
+    resolved_root = vault_root.resolve()
+    notes_dir = (resolved_root / folder).resolve() if folder else resolved_root
+    if notes_dir != resolved_root and resolved_root not in notes_dir.parents:
+        raise ValueError(f"--folder must stay within the vault: {folder!r}")
     notes_dir.mkdir(parents=True, exist_ok=True)
     rendered = render_obsidian_meeting_markdown(meeting)
     path = unique_path(notes_dir / meeting_filename(meeting))

--- a/jarvis-cli/src/jarvis/wiki/obsidian.py
+++ b/jarvis-cli/src/jarvis/wiki/obsidian.py
@@ -17,16 +17,32 @@ def setup_obsidian_vault(domain_root: Path, schema: WikiDomain) -> None:  # noqa
     """Write .obsidian/ config files to the wiki/ directory.
 
     Creates:
-    - wiki/.obsidian/community-plugins.json — recommended plugins list
     - wiki/.obsidian/graph.json — color groups for concepts, queries, summaries
     - wiki/.obsidian/app.json — basic editor/display settings
+    - wiki/RECOMMENDED-PLUGINS.md — suggested (not auto-installed) plugins
+
+    Note: we deliberately do NOT write community-plugins.json. In Obsidian that
+    file lists plugins that are *installed and enabled*; writing names there makes
+    Obsidian try to load plugins the user never installed, which surfaces errors.
+    Recommendations belong in a plain note instead.
     """
     obsidian_dir = domain_root / "wiki" / ".obsidian"
     obsidian_dir.mkdir(parents=True, exist_ok=True)
 
-    # Community plugins list (not installed, just noted as recommended)
-    community_plugins = ["obsidian-marp", "dataview", "graph-analysis"]
-    _write_json(obsidian_dir / "community-plugins.json", community_plugins)
+    # Recommended plugins as a human-readable note (NOT community-plugins.json).
+    recommended = ["obsidian-marp", "dataview", "graph-analysis"]
+    readme_lines = [
+        "# Recommended Obsidian plugins",
+        "",
+        "These community plugins pair well with this vault. Install them from",
+        "Settings → Community plugins → Browse (they are not installed automatically):",
+        "",
+        *[f"- `{name}`" for name in recommended],
+        "",
+    ]
+    (domain_root / "wiki" / "RECOMMENDED-PLUGINS.md").write_text(
+        "\n".join(readme_lines), encoding="utf-8"
+    )
 
     # Graph view color groups
     graph_config = {

--- a/jarvis-cli/tests/unit/meetings/test_parser.py
+++ b/jarvis-cli/tests/unit/meetings/test_parser.py
@@ -9,9 +9,48 @@ from jarvis.meetings.parser import (
     infer_meeting_date,
     parse_meeting_document,
     render_meeting_markdown,
+    render_obsidian_meeting_markdown,
     split_markdown_sections,
 )
 from jarvis.reading_list.models import SourceDocument, SourceType
+
+
+def _plain_text_source() -> SourceDocument:
+    return SourceDocument(
+        source_type=SourceType.FILE,
+        source_ref="/tmp/sample-meeting.md",
+        title="Fallback",
+        markdown=(
+            "# Weekly Product Sync\n\n"
+            "Date: 2026-06-03\n"
+            "Participants: Julian, Aniebet, Sam\n\n"
+            "## Summary\n\nDiscussed the export path.\n\n"
+            "## Action Items\n\n- Julian to fix the vault path\n"
+        ),
+        last_modified="1:2",
+    )
+
+
+class TestPlainTextParticipants:
+    """Bare ``Participants:`` lines in the preamble should be captured (#52.3)."""
+
+    def test_participants_from_inline_field(self) -> None:
+        meeting = parse_meeting_document(_plain_text_source())
+        assert meeting.participants == ["Julian", "Aniebet", "Sam"]
+
+
+class TestRenderObsidian:
+    """Obsidian rendering should produce a first-class note (#51)."""
+
+    def test_frontmatter_tags_checkboxes_and_wikilinks(self) -> None:
+        meeting = parse_meeting_document(_plain_text_source())
+        out = render_obsidian_meeting_markdown(meeting)
+        assert out.startswith("---\n")
+        assert "title: Weekly Product Sync" in out
+        assert "participants:\n  - Julian" in out
+        assert "- meeting" in out  # #meeting tag in frontmatter
+        assert "[[Julian]]" in out
+        assert "- [ ] Julian to fix the vault path" in out
 
 
 class TestSplitMarkdownSections:

--- a/jarvis-cli/tests/unit/meetings/test_parser.py
+++ b/jarvis-cli/tests/unit/meetings/test_parser.py
@@ -15,7 +15,10 @@ from jarvis.meetings.parser import (
 from jarvis.reading_list.models import SourceDocument, SourceType
 
 
-def _plain_text_source() -> SourceDocument:
+@pytest.fixture
+def plain_text_source() -> SourceDocument:
+    """A plain-text meeting with bare preamble fields and no markdown sections."""
+
     return SourceDocument(
         source_type=SourceType.FILE,
         source_ref="/tmp/sample-meeting.md",
@@ -34,16 +37,20 @@ def _plain_text_source() -> SourceDocument:
 class TestPlainTextParticipants:
     """Bare ``Participants:`` lines in the preamble should be captured (#52.3)."""
 
-    def test_participants_from_inline_field(self) -> None:
-        meeting = parse_meeting_document(_plain_text_source())
+    def test_participants_from_inline_field(self, plain_text_source: SourceDocument) -> None:
+        """A bare ``Participants:`` line is parsed into the participant list."""
+        meeting = parse_meeting_document(plain_text_source)
         assert meeting.participants == ["Julian", "Aniebet", "Sam"]
 
 
 class TestRenderObsidian:
     """Obsidian rendering should produce a first-class note (#51)."""
 
-    def test_frontmatter_tags_checkboxes_and_wikilinks(self) -> None:
-        meeting = parse_meeting_document(_plain_text_source())
+    def test_frontmatter_tags_checkboxes_and_wikilinks(
+        self, plain_text_source: SourceDocument
+    ) -> None:
+        """Rendered note carries frontmatter, tags, checkboxes, and wikilinks."""
+        meeting = parse_meeting_document(plain_text_source)
         out = render_obsidian_meeting_markdown(meeting)
         assert out.startswith("---\n")
         assert "title: Weekly Product Sync" in out
@@ -51,6 +58,17 @@ class TestRenderObsidian:
         assert "- meeting" in out  # #meeting tag in frontmatter
         assert "[[Julian]]" in out
         assert "- [ ] Julian to fix the vault path" in out
+
+    def test_existing_checkbox_marker_not_duplicated(
+        self, plain_text_source: SourceDocument
+    ) -> None:
+        """Action items already prefixed with [ ] are not double-marked."""
+        meeting = parse_meeting_document(plain_text_source)
+        meeting.action_items = ["[ ] already a checkbox", "[x] done item"]
+        out = render_obsidian_meeting_markdown(meeting)
+        assert "- [ ] already a checkbox" in out
+        assert "- [ ] [ ]" not in out
+        assert "- [ ] done item" in out
 
 
 class TestSplitMarkdownSections:


### PR DESCRIPTION
## Summary

Fixes the Obsidian-path issues from real user testing: **#50**, **#51**, and all three sub-items of **#52**. Verified end-to-end (ingest → open in a real Obsidian vault) and with new unit tests.

## What each commit fixes

- **#50 — notes saved outside the vault.** `raw/notes/` is actually a *compiler input* (`wiki compile` builds the vault from it), so the path wasn't a typo. Added a dedicated **`obsidian` destination** that writes a finished note straight into a real vault, as the reporter suggested:
  ```
  jarvis meeting ingest <file> --dest obsidian --vault "<vault path>" --folder Meetings
  ```
  The `wiki` destination is unchanged (still stages raw input for `wiki compile`).
- **#51 — not proper Obsidian notes.** New `render_obsidian_meeting_markdown` emits YAML **frontmatter** (Properties), a **`#meeting`** tag, action items as **`- [ ]` checkboxes**, and **`[[wikilinks]]`** for participants — so graph view, backlinks, and the tasks view all work.
- **#52.1 — Windows `UnicodeEncodeError`.** Reconfigure CLI stdout/stderr to UTF-8 (with `errors="replace"`) at the entry point, so glyphs like `✓`/`→` don't crash on the default Windows console. One fix covers all commands.
- **#52.2 — plugins written to wrong file.** Stopped writing `.obsidian/community-plugins.json` (Obsidian reads that as *installed+enabled*); recommendations now go to a plain `RECOMMENDED-PLUGINS.md`.
- **#52.3 — participants dropped.** Plain-text/manual notes with a bare `Participants: a, b, c` line now parse correctly, not only `## Participants` sections.

## Verification

Reproduced the reporter's flow, then ran the new path:

```
$ jarvis meeting ingest sample.md --dest obsidian --vault /tmp/myvault --no-enrich-ai
Wrote: /tmp/myvault/Meetings/2026-06-03-weekly-product-sync.md
```

Produces (opens as a first-class note in Obsidian 1.12.7, confirmed visually):

```markdown
---
title: Weekly Product Sync
date: 2026-06-03
type: meeting
participants:
  - Julian
  - Aniebet
  - Sam
tags:
  - meeting
---
# Weekly Product Sync
> [!info] Meeting
> **Date:** 2026-06-03 · **People:** [[Julian]], [[Aniebet]], [[Sam]]
...
## Action Items
- [ ] Julian to fix the vault path
```

- `ruff check` on all changed files — clean
- `pytest tests/unit/meetings` — **60 passed** (incl. new tests for plain-text participants + the Obsidian renderer)

Closes #50, closes #51, closes #52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Obsidian vault integration for meeting notes with configurable vault and folder options.
  * Meeting renderer outputs Obsidian-ready markdown with frontmatter, tags, wikilinks, callouts, and checkbox action items.
  * Parser now extracts inline Key: Value metadata from note preambles.

* **Bug Fixes**
  * Prevents Unicode encoding errors on Windows consoles.

* **Documentation**
  * Plugin recommendations delivered as a human-readable markdown guide (no JSON). 

* **Tests**
  * Added tests for inline field parsing and Obsidian rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->