### PR TITLE
feat(ratchet): instrument the autoresearch loop — score history, real cost tracking, safe auto-revert

### DIFF
--- a/program.md
+++ b/program.md
@@ -32,6 +32,17 @@ S = f^0.35 · p^0.20 · q^0.20 · (1-r)^0.10 · (1-h)^0.10 · (1-c)^0.05
 
 Adds **h** (human intervention rate) and **c** (normalized cost).
 
+**Cost normalization** — `c` is the average per-run cost divided by
+`target_cost` (a per-run USD budget), capped at 1.0. Run records supply cost
+via `cost_usd`, or via `tokens_in`/`tokens_out` priced with the rates below.
+Runs with no cost signal are excluded from the average (never counted as free).
+
+```
+target_cost: 1.0            # per-run USD budget; a run at budget → c = 1.0
+price_per_1k_input: 0.0     # $ per 1K input tokens (0 = disabled)
+price_per_1k_output: 0.0    # $ per 1K output tokens (0 = disabled)
+```
+
 ### Hard Constraints (vetoes — reject improvement if violated)
 
 These are disqualifying, not "a little bad." Any violation rejects the

--- a/tests/ratchet/test_ratchet_history.py
+++ b/tests/ratchet/test_ratchet_history.py
@@ -8,6 +8,7 @@ Pure stdlib (unittest) so it runs without the jarvis-cli dependency set:
 
 import importlib.util
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -88,6 +89,113 @@ class ScoreHistoryTest(unittest.TestCase):
         ratchet.append_score_history("b", 1, 0.6, variables)
         self.assertEqual(len(ratchet.load_score_history("a")), 1)
         self.assertEqual(len(ratchet.load_score_history()), 2)
+
+
+class CostExtractionTest(unittest.TestCase):
+    """Thrust B: real cost tracking feeds the `c` dimension."""
+
+    def _cfg(self, **overrides):
+        cfg = dict(ratchet.DEFAULT_CONFIG)
+        cfg.update(overrides)
+        return cfg
+
+    def test_cost_usd_used_directly(self):
+        cfg = self._cfg(target_cost=1.0)
+        runs = [{"outcome": "completed", "cost_usd": 0.5},
+                {"outcome": "completed", "cost_usd": 1.5}]
+        v = ratchet.extract_variables(runs, [], cfg)
+        self.assertEqual(v["raw"]["runs_with_cost"], 2)
+        self.assertAlmostEqual(v["raw"]["avg_cost_usd"], 1.0)
+        self.assertAlmostEqual(v["c"], 1.0)  # avg 1.0 / budget 1.0, capped
+
+    def test_tokens_priced_when_no_cost_usd(self):
+        cfg = self._cfg(price_per_1k_input=0.003, price_per_1k_output=0.015, target_cost=1.0)
+        runs = [{"outcome": "completed", "tokens_in": 1000, "tokens_out": 1000}]
+        cost = ratchet.run_cost_usd(runs[0], cfg)
+        self.assertAlmostEqual(cost, 0.018)
+        v = ratchet.extract_variables(runs, [], cfg)
+        self.assertEqual(v["raw"]["total_tokens_in"], 1000)
+        self.assertAlmostEqual(v["raw"]["avg_cost_usd"], 0.018)
+
+    def test_legacy_cost_field_back_compat(self):
+        self.assertAlmostEqual(ratchet.run_cost_usd({"cost": 0.3}, self._cfg()), 0.3)
+
+    def test_no_cost_signal_is_excluded_not_free(self):
+        cfg = self._cfg(target_cost=1.0)
+        runs = [{"outcome": "completed"}, {"outcome": "completed"}]
+        v = ratchet.extract_variables(runs, [], cfg)
+        self.assertEqual(v["raw"]["runs_with_cost"], 0)
+        self.assertEqual(v["c"], 0.0)
+
+
+class RevertSafetyTest(unittest.TestCase):
+    """Thrust C: safe, auditable auto-revert."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.repo = Path(self._tmp.name)
+        self._cwd = os.getcwd()
+        os.chdir(self.repo)
+
+        env = {"GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+               "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+        os.environ.update(env)
+        subprocess.run(["git", "init", "-q"], check=True)
+
+        self.skills = self.repo / "skills"
+        self.skill_dir = self.skills / "demo"
+        self.skill_dir.mkdir(parents=True)
+        (self.skill_dir / "a.txt").write_text("baseline\n")
+        subprocess.run(["git", "add", "-A"], check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "baseline"], check=True)
+        self.tag = "ratchet/demo/snap"
+        subprocess.run(["git", "tag", self.tag], check=True)
+
+        # Improvement: modify a.txt, add a tracked orphan and an untracked orphan.
+        (self.skill_dir / "a.txt").write_text("improved\n")
+        (self.skill_dir / "c.txt").write_text("added-tracked\n")
+        subprocess.run(["git", "add", str(self.skill_dir / "c.txt")], check=True)
+        subprocess.run(["git", "commit", "-q", "-m", "improve"], check=True)
+        (self.skill_dir / "b.txt").write_text("added-untracked\n")
+
+        os.environ["AGENTS_SKILLS_ROOT"] = str(self.skills)
+        self._orig_state_dir = ratchet.autoflow_state_dir
+        ratchet.autoflow_state_dir = lambda: self.repo / "state"
+
+    def tearDown(self):
+        ratchet.autoflow_state_dir = self._orig_state_dir
+        os.chdir(self._cwd)
+        self._tmp.cleanup()
+
+    def test_tag_exists(self):
+        self.assertTrue(ratchet.tag_exists(self.tag))
+        self.assertFalse(ratchet.tag_exists("ratchet/demo/missing"))
+
+    def test_plan_identifies_orphans(self):
+        plan = ratchet.build_revert_plan("demo", self.tag)
+        self.assertIn("skills/demo/c.txt", plan["orphan_tracked"])
+        self.assertIn("skills/demo/b.txt", plan["orphan_untracked"])
+        self.assertTrue(any(f.endswith("a.txt") for f in plan["restore_files"]))
+
+    def test_missing_tag_aborts_without_mutation(self):
+        result = ratchet.perform_revert("demo", "ratchet/demo/missing")
+        self.assertFalse(result["reverted"])
+        self.assertIn("error", result)
+        self.assertEqual((self.skill_dir / "a.txt").read_text(), "improved\n")
+
+    def test_revert_restores_and_writes_evidence(self):
+        result = ratchet.perform_revert("demo", self.tag)
+        self.assertTrue(result["reverted"])
+        self.assertEqual((self.skill_dir / "a.txt").read_text(), "baseline\n")
+        # Orphans survive a plain revert.
+        self.assertTrue((self.skill_dir / "c.txt").exists())
+        self.assertTrue(Path(result["evidence"]).exists())
+
+    def test_clean_removes_orphans(self):
+        result = ratchet.perform_revert("demo", self.tag, clean=True)
+        self.assertTrue(result["reverted"])
+        self.assertFalse((self.skill_dir / "c.txt").exists())
+        self.assertFalse((self.skill_dir / "b.txt").exists())
 
 
 class HelpOutputTest(unittest.TestCase):

--- a/tests/ratchet/test_ratchet_history.py
+++ b/tests/ratchet/test_ratchet_history.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Tests for ratchet.py score history + comprehensive help (issues #27, #28).
+
+Pure stdlib (unittest) so it runs without the jarvis-cli dependency set:
+
+    python3 tests/ratchet/test_ratchet_history.py
+"""
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RATCHET_PATH = REPO_ROOT / "tools" / "flow-install" / "skills" / "_shared" / "ratchet.py"
+
+
+def _load_ratchet():
+    spec = importlib.util.spec_from_file_location("ratchet", RATCHET_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+ratchet = _load_ratchet()
+
+REQUIRED_KEYS = ("timestamp", "skill", "score", "f", "p", "q", "r")
+
+
+class ScoreHistoryTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+        self._orig_state_dir = ratchet.autoflow_state_dir
+        ratchet.autoflow_state_dir = lambda: self.tmp
+
+    def tearDown(self):
+        ratchet.autoflow_state_dir = self._orig_state_dir
+        self._tmp.cleanup()
+
+    def _read_history(self):
+        return ratchet.score_history_path().read_text().splitlines()
+
+    def test_two_scores_produce_two_entries(self):
+        variables = {"f": 0.9, "p": 0.8, "q": 0.7, "r": 0.1}
+        ratchet.append_score_history("issue-flow", 1, 0.5, variables)
+        ratchet.append_score_history("issue-flow", 1, 0.6, variables)
+
+        lines = self._read_history()
+        self.assertGreaterEqual(len(lines), 2)
+
+    def test_each_entry_is_valid_json_with_required_keys(self):
+        variables = {"f": 0.9, "p": 0.8, "q": 0.7, "r": 0.1}
+        ratchet.append_score_history("issue-flow", 1, 0.5, variables)
+
+        entry = json.loads(self._read_history()[0])
+        for key in REQUIRED_KEYS:
+            self.assertIn(key, entry)
+        self.assertEqual(entry["skill"], "issue-flow")
+        self.assertEqual(entry["score"], 0.5)
+
+    def test_history_is_append_only(self):
+        variables = {"f": 0.9, "p": 0.8, "q": 0.7, "r": 0.1}
+        ratchet.append_score_history("a", 1, 0.5, variables)
+        first = self._read_history()[0]
+
+        ratchet.append_score_history("b", 1, 0.6, variables)
+        lines = self._read_history()
+
+        # Original line is preserved verbatim; file only grows.
+        self.assertEqual(lines[0], first)
+        self.assertEqual(len(lines), 2)
+
+    def test_layer_two_records_h_and_c(self):
+        variables = {"f": 0.9, "p": 0.8, "q": 0.7, "r": 0.1, "h": 0.2, "c": 0.3}
+        ratchet.append_score_history("issue-flow", 2, 0.5, variables)
+        entry = json.loads(self._read_history()[0])
+        self.assertEqual(entry["layer"], 2)
+        self.assertEqual(entry["h"], 0.2)
+        self.assertEqual(entry["c"], 0.3)
+
+    def test_load_score_history_filters_by_skill(self):
+        variables = {"f": 0.9, "p": 0.8, "q": 0.7, "r": 0.1}
+        ratchet.append_score_history("a", 1, 0.5, variables)
+        ratchet.append_score_history("b", 1, 0.6, variables)
+        self.assertEqual(len(ratchet.load_score_history("a")), 1)
+        self.assertEqual(len(ratchet.load_score_history()), 2)
+
+
+class HelpOutputTest(unittest.TestCase):
+    """Issue #28: top-level and per-subcommand help must succeed and describe usage."""
+
+    SUBCOMMANDS = ("score", "gates", "snapshot", "evaluate", "decide", "status", "history")
+
+    def _run(self, *args):
+        return subprocess.run(
+            [sys.executable, str(RATCHET_PATH), *args],
+            capture_output=True, text=True,
+        )
+
+    def test_top_level_help_lists_all_subcommands(self):
+        result = self._run("--help")
+        self.assertEqual(result.returncode, 0)
+        for cmd in self.SUBCOMMANDS:
+            self.assertIn(cmd, result.stdout)
+
+    def test_each_subcommand_help_has_example(self):
+        for cmd in self.SUBCOMMANDS:
+            result = self._run(cmd, "--help")
+            self.assertEqual(result.returncode, 0, f"{cmd} --help failed")
+            self.assertIn("examples:", result.stdout, f"{cmd} --help missing examples")
+            self.assertIn(f"ratchet.py {cmd}", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tools/flow-install/skills/_shared/autoresearch.md
+++ b/tools/flow-install/skills/_shared/autoresearch.md
@@ -94,6 +94,17 @@ Decision logic:
 3. ΔS < -ε → **REVERT**
 4. |ΔS| ≤ ε → **KEEP** (no regression)
 
+### History
+
+Every `score` invocation is appended to an append-only log at
+`.jarvis/context/autoflow/score_history.ndjson` (one JSON object per line:
+timestamp, skill, layer, score, and the individual variables). Inspect the
+trend at any time:
+```bash
+python3 "${AGENTS_SKILLS_ROOT}/_shared/ratchet.py" history --skill <name> --last 10
+```
+Pass `score --no-history` to compute a score without recording it.
+
 ## The Metric
 
 ### Layer 1 (default — start here)

--- a/tools/flow-install/skills/_shared/ratchet.py
+++ b/tools/flow-install/skills/_shared/ratchet.py
@@ -49,7 +49,13 @@ DEFAULT_CONFIG = {
     "max_loops": 5.0,
     "max_regression_rate": 0.1,
     "max_human_intervention": 0.5,
+    # Cost normalization. target_cost is the per-run USD budget the cost
+    # dimension (c) is normalized against: a run at target_cost maps to c=1.0.
+    # When runs carry token counts instead of a direct cost_usd, they are
+    # priced with these per-1K-token rates (0 = disabled).
     "target_cost": 1.0,
+    "price_per_1k_input": 0.0,
+    "price_per_1k_output": 0.0,
     "evaluation_window": 3,
     # Layer 1 exponents
     "layer_1": {"f": 0.35, "p": 0.25, "q": 0.25, "r": 0.15},
@@ -134,6 +140,51 @@ def load_runs(skill: Optional[str] = None) -> List[Dict[str, Any]]:
     return runs
 
 
+# --- Cost extraction ---
+
+def _run_tokens(run: Dict[str, Any]) -> Optional[Dict[str, int]]:
+    """Extract input/output token counts from a run record, if present.
+
+    Accepts either flat keys (tokens_in / tokens_out) or a nested
+    `tokens: {"in": ..., "out": ...}` object.
+    """
+    tokens = run.get("tokens")
+    if isinstance(tokens, dict):
+        tin = tokens.get("in", tokens.get("input"))
+        tout = tokens.get("out", tokens.get("output"))
+    else:
+        tin = run.get("tokens_in")
+        tout = run.get("tokens_out")
+    if tin is None and tout is None:
+        return None
+    return {"in": int(tin or 0), "out": int(tout or 0)}
+
+
+def run_cost_usd(run: Dict[str, Any], config: Dict[str, Any]) -> Optional[float]:
+    """Compute a single run's cost in USD, or None if the run has no cost data.
+
+    Resolution order:
+      1. explicit `cost_usd`
+      2. token counts priced with configured per-1K rates
+      3. legacy `cost` field (back-compat)
+    A run with no cost signal returns None so it is excluded from the average
+    rather than being counted as free.
+    """
+    if run.get("cost_usd") is not None:
+        return float(run["cost_usd"])
+
+    tokens = _run_tokens(run)
+    if tokens is not None:
+        price_in = config.get("price_per_1k_input", 0.0)
+        price_out = config.get("price_per_1k_output", 0.0)
+        return (tokens["in"] / 1000.0) * price_in + (tokens["out"] / 1000.0) * price_out
+
+    if run.get("cost") is not None:
+        return float(run["cost"])
+
+    return None
+
+
 # --- Variable extraction ---
 
 def extract_variables(
@@ -185,10 +236,17 @@ def extract_variables(
             human_total_total += htotal
     h = human_triggered_total / human_total_total if human_total_total > 0 else 0.0
 
-    # c = normalized cost (deferred — uses placeholder)
+    # c = normalized cost. Averaged only over runs that carry a cost signal
+    # (cost_usd, token counts, or legacy cost); runs without cost data are
+    # excluded so missing instrumentation reads as c=0 rather than free.
     target_cost = config.get("target_cost", DEFAULT_CONFIG["target_cost"])
-    avg_cost = sum(r.get("cost", 0.0) for r in runs) / len(runs) if runs else 0.0
+    run_costs = [rc for rc in (run_cost_usd(run, config) for run in runs) if rc is not None]
+    avg_cost = sum(run_costs) / len(run_costs) if run_costs else 0.0
     c = min(avg_cost / target_cost, 1.0) if target_cost > 0 else 0.0
+
+    token_totals = [_run_tokens(run) for run in runs]
+    total_tokens_in = sum(t["in"] for t in token_totals if t)
+    total_tokens_out = sum(t["out"] for t in token_totals if t)
 
     return {
         "f": round(f, 4),
@@ -205,6 +263,10 @@ def extract_variables(
             "tests_total": tests_total_total,
             "human_gates_triggered": human_triggered_total,
             "human_gates_total": human_total_total,
+            "runs_with_cost": len(run_costs),
+            "avg_cost_usd": round(avg_cost, 6),
+            "total_tokens_in": total_tokens_in,
+            "total_tokens_out": total_tokens_out,
         },
     }
 
@@ -591,6 +653,139 @@ def command_evaluate(args: argparse.Namespace) -> int:
     return 0
 
 
+# --- Git revert safety ---
+
+def _git(args: List[str], check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", *args], capture_output=True, text=True, check=check)
+
+
+def tag_exists(tag: str) -> bool:
+    """Return True if the given ref resolves to a commit."""
+    return _git(["rev-parse", "--verify", "--quiet", f"{tag}^{{commit}}"], check=False).returncode == 0
+
+
+def _files_at_ref(ref: str, path: str) -> set:
+    result = _git(["ls-tree", "-r", "--name-only", ref, "--", path], check=False)
+    if result.returncode != 0:
+        return set()
+    return {line for line in result.stdout.splitlines() if line.strip()}
+
+
+def _tracked_files_now(path: str) -> set:
+    result = _git(["ls-files", "--", path], check=False)
+    return {line for line in result.stdout.splitlines() if line.strip()}
+
+
+def _untracked_files_now(path: str) -> set:
+    result = _git(["ls-files", "--others", "--exclude-standard", "--", path], check=False)
+    return {line for line in result.stdout.splitlines() if line.strip()}
+
+
+def reverts_dir() -> Path:
+    return autoflow_state_dir() / "reverts"
+
+
+def build_revert_plan(skill: str, tag: str) -> Dict[str, Any]:
+    """Describe what a revert to `tag` would change, without touching anything.
+
+    Orphan files exist in the working tree now but not in the snapshot tag,
+    so a path-scoped `git checkout` would leave them behind. They are what
+    makes a naive revert incomplete.
+    """
+    skill_path = str(skills_root() / skill)
+    at_tag = _files_at_ref(tag, skill_path)
+    tracked_now = _tracked_files_now(skill_path)
+
+    diff = _git(["diff", "--stat", tag, "--", skill_path], check=False)
+    return {
+        "skill": skill,
+        "tag": tag,
+        "tag_exists": tag_exists(tag),
+        "skill_path": skill_path,
+        "restore_files": sorted(at_tag),
+        "orphan_tracked": sorted(tracked_now - at_tag),
+        "orphan_untracked": sorted(_untracked_files_now(skill_path)),
+        "diffstat": diff.stdout.strip() if diff.returncode == 0 else "",
+    }
+
+
+def write_revert_evidence(skill: str, tag: str, plan: Dict[str, Any]) -> Path:
+    """Persist an auditable record of what a revert discarded."""
+    d = reverts_dir()
+    d.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    skill_path = plan["skill_path"]
+
+    diff = _git(["diff", tag, "--", skill_path], check=False)
+    (d / f"{skill}_{ts}.diff").write_text(diff.stdout if diff.returncode == 0 else "")
+
+    manifest_path = d / f"{skill}_{ts}.json"
+    manifest = {
+        "skill": skill,
+        "tag": tag,
+        "reverted_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "restore_files": plan["restore_files"],
+        "orphan_tracked": plan["orphan_tracked"],
+        "orphan_untracked": plan["orphan_untracked"],
+        "diffstat": plan["diffstat"],
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+    return manifest_path
+
+
+def perform_revert(skill: str, tag: str, clean: bool = False) -> Dict[str, Any]:
+    """Restore a skill's files to a snapshot tag, with evidence.
+
+    Returns a result dict. On failure the returned dict contains an "error"
+    key and no mutation beyond what git itself applied.
+    """
+    skill_path = str(skills_root() / skill)
+
+    if not tag_exists(tag):
+        return {"error": f"Snapshot tag not found: {tag}", "reverted": False}
+
+    plan = build_revert_plan(skill, tag)
+    evidence = write_revert_evidence(skill, tag, plan)
+
+    try:
+        _git(["checkout", tag, "--", skill_path])
+    except subprocess.CalledProcessError as e:
+        return {"error": f"Git revert failed: {e.stderr.strip()}", "reverted": False,
+                "evidence": str(evidence)}
+
+    removed: List[str] = []
+    if clean:
+        for f in plan["orphan_tracked"]:
+            if _git(["rm", "-f", "--", f], check=False).returncode == 0:
+                removed.append(f)
+        for f in plan["orphan_untracked"]:
+            try:
+                Path(f).unlink()
+                removed.append(f)
+            except OSError:
+                pass
+
+    return {
+        "reverted": True,
+        "tag": tag,
+        "restored": len(plan["restore_files"]),
+        "orphan_tracked": plan["orphan_tracked"],
+        "orphan_untracked": plan["orphan_untracked"],
+        "removed_orphans": removed,
+        "evidence": str(evidence),
+    }
+
+
+def _classify_decision(delta: float, epsilon: float, gates_passed: bool) -> tuple:
+    if not gates_passed:
+        return "revert", "hard constraint gate failed"
+    if delta > epsilon:
+        return "keep", f"delta {delta:+.4f} exceeds epsilon {epsilon}"
+    if delta < -epsilon:
+        return "revert", f"delta {delta:+.4f} below negative epsilon {-epsilon}"
+    return "keep", f"delta {delta:+.4f} within noise band (no regression)"
+
+
 def command_decide(args: argparse.Namespace) -> int:
     """Make binary keep/revert decision.
 
@@ -599,6 +794,10 @@ def command_decide(args: argparse.Namespace) -> int:
       2. If ΔS > ε → KEEP
       3. If ΔS < -ε → REVERT
       4. If |ΔS| ≤ ε → KEEP (no regression, within noise)
+
+    A revert restores the skill to its snapshot tag. --dry-run reports the
+    decision and the revert plan (files to restore, orphan files that would
+    survive) without touching git or ratchet state.
     """
     skill = args.skill
 
@@ -616,31 +815,43 @@ def command_decide(args: argparse.Namespace) -> int:
     gates_passed = state.get("gates_passed", True)
     tag = state.get("snapshot_tag")
 
-    # Decision
-    if not gates_passed:
-        decision = "revert"
-        reason = "hard constraint gate failed"
-    elif delta > epsilon:
-        decision = "keep"
-        reason = f"delta {delta:+.4f} exceeds epsilon {epsilon}"
-    elif delta < -epsilon:
-        decision = "revert"
-        reason = f"delta {delta:+.4f} below negative epsilon {-epsilon}"
-    else:
-        decision = "keep"
-        reason = f"delta {delta:+.4f} within noise band (no regression)"
+    decision, reason = _classify_decision(delta, epsilon, gates_passed)
 
-    # Execute decision
+    # Dry run: report the decision and, for a revert, the plan — mutate nothing.
+    if args.dry_run:
+        result: Dict[str, Any] = {
+            "dry_run": True,
+            "decision": decision,
+            "reason": reason,
+            "delta": delta,
+            "tag": tag,
+        }
+        if decision == "revert" and tag:
+            result["revert_plan"] = build_revert_plan(skill, tag)
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"=== {skill} Ratchet Decision (dry-run): would {decision.upper()} ===")
+            print(f"  Reason: {reason}")
+            if decision == "revert" and tag:
+                plan = result["revert_plan"]
+                if not plan["tag_exists"]:
+                    print(f"  ⚠ snapshot tag missing: {tag}")
+                print(f"  Would restore {len(plan['restore_files'])} file(s) from {tag}")
+                orphans = plan["orphan_tracked"] + plan["orphan_untracked"]
+                if orphans:
+                    print(f"  ⚠ {len(orphans)} orphan file(s) would remain (use --clean to remove):")
+                    for f in orphans:
+                        print(f"      {f}")
+        return 0
+
+    # Execute revert.
+    revert_result: Optional[Dict[str, Any]] = None
     if decision == "revert" and tag:
-        skill_path = skills_root() / skill
-        try:
-            subprocess.run(
-                ["git", "checkout", tag, "--", str(skill_path)],
-                check=True, capture_output=True, text=True,
-            )
-        except subprocess.CalledProcessError as e:
+        revert_result = perform_revert(skill, tag, clean=args.clean)
+        if revert_result.get("error"):
             print(json.dumps({
-                "error": f"Git revert failed: {e.stderr.strip()}",
+                "error": revert_result["error"],
                 "decision": decision,
                 "reason": reason,
             }), file=sys.stderr)
@@ -651,6 +862,9 @@ def command_decide(args: argparse.Namespace) -> int:
     state["decision"] = decision
     state["reason"] = reason
     state["decided_at"] = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    if revert_result:
+        state["revert_evidence"] = revert_result.get("evidence")
+        state["orphan_files"] = revert_result.get("orphan_tracked", []) + revert_result.get("orphan_untracked", [])
     save_ratchet_state(skill, state)
 
     result = {
@@ -661,6 +875,8 @@ def command_decide(args: argparse.Namespace) -> int:
         "delta": delta,
         "tag": tag,
     }
+    if revert_result:
+        result["revert"] = revert_result
 
     if args.json:
         print(json.dumps(result, indent=2))
@@ -671,8 +887,13 @@ def command_decide(args: argparse.Namespace) -> int:
         print(f"  Baseline:  {state.get('baseline_score', '?')}")
         print(f"  Candidate: {state.get('candidate_score', '?')}")
         print(f"  Delta:     {delta:+.4f}")
-        if decision == "revert":
+        if decision == "revert" and revert_result:
             print(f"  Reverted to: {tag}")
+            print(f"  Restored:    {revert_result.get('restored', 0)} file(s)")
+            print(f"  Evidence:    {revert_result.get('evidence')}")
+            orphans = revert_result.get("orphan_tracked", []) + revert_result.get("orphan_untracked", [])
+            if orphans and not args.clean:
+                print(f"  ⚠ {len(orphans)} orphan file(s) left behind (use --clean to remove)")
 
     return 0
 
@@ -856,13 +1077,19 @@ def parse_args() -> argparse.Namespace:
         "Make keep/revert decision",
         "Make the binary keep/revert decision from the latest evaluation. A "
         "failed gate or a delta below -epsilon reverts the skill to its snapshot "
-        "tag; otherwise the change is kept. Requires 'snapshot' then 'evaluate'.",
+        "tag; otherwise the change is kept. A revert writes an evidence diff to "
+        ".jarvis/context/autoflow/reverts/. Requires 'snapshot' then 'evaluate'.",
         "examples:\n"
         "  ratchet.py decide --skill issue-flow\n"
-        "  ratchet.py decide --skill issue-flow --json",
+        "  ratchet.py decide --skill issue-flow --dry-run\n"
+        "  ratchet.py decide --skill issue-flow --clean --json",
     )
     dc.add_argument("--skill", required=True, help="Skill name to decide on")
     dc.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+    dc.add_argument("--dry-run", action="store_true",
+                    help="Report the decision and revert plan without mutating git or state.")
+    dc.add_argument("--clean", action="store_true",
+                    help="On revert, also remove orphan files not present in the snapshot tag.")
 
     # status
     st = add(

--- a/tools/flow-install/skills/_shared/ratchet.py
+++ b/tools/flow-install/skills/_shared/ratchet.py
@@ -108,6 +108,10 @@ def runs_path() -> Path:
     return autoflow_state_dir() / "runs.ndjson"
 
 
+def score_history_path() -> Path:
+    return autoflow_state_dir() / "score_history.ndjson"
+
+
 # --- Run record loading ---
 
 def load_runs(skill: Optional[str] = None) -> List[Dict[str, Any]]:
@@ -310,6 +314,64 @@ def save_ratchet_state(skill: str, state: Dict[str, Any]) -> None:
     path.write_text(json.dumps(state, indent=2) + "\n")
 
 
+# --- Score history (append-only) ---
+
+def append_score_history(
+    skill: str,
+    layer: int,
+    score: float,
+    variables: Dict[str, Any],
+) -> Path:
+    """Append one score computation to the append-only history log.
+
+    Each line is a self-contained JSON object with the timestamp, skill,
+    layer, composite score, and the individual normalized variables. The file
+    is opened in append mode and never truncated, so it forms a durable
+    time-series of how a skill's ratchet score evolves across runs.
+    """
+    path = score_history_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    entry: Dict[str, Any] = {
+        "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "skill": skill,
+        "layer": layer,
+        "score": score,
+        "f": variables.get("f"),
+        "p": variables.get("p"),
+        "q": variables.get("q"),
+        "r": variables.get("r"),
+    }
+    # Layer-2 variables are only meaningful when present.
+    if layer >= 2:
+        entry["h"] = variables.get("h")
+        entry["c"] = variables.get("c")
+
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(entry) + "\n")
+    return path
+
+
+def load_score_history(skill: Optional[str] = None) -> List[Dict[str, Any]]:
+    """Load score history entries, optionally filtered by skill."""
+    path = score_history_path()
+    if not path.exists():
+        return []
+    entries: List[Dict[str, Any]] = []
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if skill and record.get("skill") != skill:
+            continue
+        entries.append(record)
+    return entries
+
+
 # --- CLI commands ---
 
 def command_score(args: argparse.Namespace) -> int:
@@ -323,6 +385,9 @@ def command_score(args: argparse.Namespace) -> int:
     config = dict(DEFAULT_CONFIG)
     variables = extract_variables(runs, traces, config)
     score = compute_score(variables, layer=layer)
+
+    if not args.no_history:
+        append_score_history(skill, layer, score, variables)
 
     result = {
         "skill": skill,
@@ -643,49 +708,192 @@ def command_status(args: argparse.Namespace) -> int:
     return 0
 
 
+def command_history(args: argparse.Namespace) -> int:
+    """Show the recorded score history as a time-series trend."""
+    entries = load_score_history(args.skill)
+    if args.last:
+        entries = entries[-args.last:]
+
+    if args.json:
+        print(json.dumps({"skill": args.skill, "count": len(entries), "history": entries}, indent=2))
+        return 0
+
+    if not entries:
+        print(f"=== {args.skill} Score History ===")
+        print("  (no history yet — run 'ratchet.py score' first)")
+        return 0
+
+    print(f"=== {args.skill} Score History (last {len(entries)}) ===")
+    prev: Optional[float] = None
+    for entry in entries:
+        score = entry.get("score", 0.0)
+        ts = str(entry.get("timestamp", ""))[:19]
+        # Sparkline-style bar over the [0, 1] score range.
+        filled = int(round(score * 20))
+        bar = "█" * filled + "░" * (20 - filled)
+        if prev is None:
+            arrow = " "
+        elif score > prev:
+            arrow = "↑"
+        elif score < prev:
+            arrow = "↓"
+        else:
+            arrow = "="
+        print(f"  {ts}  {bar}  {score:.4f} {arrow}  (L{entry.get('layer', 1)})")
+        prev = score
+
+    return 0
+
+
 # --- Argument parsing ---
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Autoresearch ratchet: multiplicative composite metric with hard constraint gates"
+        prog="ratchet.py",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=(
+            "Autoresearch ratchet: multiplicative composite metric with hard "
+            "constraint gates.\n\n"
+            "Runs the keep/revert loop for a skill: snapshot a baseline, let new "
+            "runs accumulate, evaluate the candidate against the baseline, and "
+            "make a binary keep/revert decision. 'score' and 'gates' are "
+            "read-only inspections; 'history' shows the recorded score trend."
+        ),
+        epilog=(
+            "examples:\n"
+            "  ratchet.py score --skill issue-flow\n"
+            "  ratchet.py score --skill issue-flow --layer 2 --verbose\n"
+            "  ratchet.py history --skill issue-flow --last 10\n"
+            "  ratchet.py snapshot --skill issue-flow\n"
+            "  ratchet.py evaluate --skill issue-flow --window 3\n"
+            "  ratchet.py decide --skill issue-flow\n\n"
+            "Run 'ratchet.py <command> --help' for command-specific options."
+        ),
     )
-    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers = parser.add_subparsers(dest="command", metavar="<command>", required=True)
+
+    def add(name: str, help_text: str, description: str, epilog: str):
+        return subparsers.add_parser(
+            name,
+            help=help_text,
+            description=description,
+            epilog=epilog,
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+        )
 
     # score
-    sc = subparsers.add_parser("score", help="Compute composite score")
-    sc.add_argument("--skill", required=True)
-    sc.add_argument("--layer", type=int, default=1, choices=[1, 2])
-    sc.add_argument("--json", action="store_true")
+    sc = add(
+        "score",
+        "Compute composite score",
+        "Compute the multiplicative composite ratchet score from recorded runs "
+        "and traces. Each invocation is appended to the score history log "
+        "(disable with --no-history).",
+        "examples:\n"
+        "  ratchet.py score --skill issue-flow\n"
+        "  ratchet.py score --skill issue-flow --layer 2 --verbose\n"
+        "  ratchet.py score --skill issue-flow --json --no-history",
+    )
+    sc.add_argument("--skill", required=True, help="Skill name to score (e.g. issue-flow)")
+    sc.add_argument("--layer", type=int, default=1, choices=[1, 2],
+                    help="Metric layer: 1 (f/p/q/r) or 2 (adds h/c). Default: 1")
+    sc.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
     sc.add_argument(
         "--verbose",
         action="store_true",
         help="Print a per-variable breakdown (raw value, weight, weighted contribution).",
     )
+    sc.add_argument(
+        "--no-history",
+        action="store_true",
+        help="Do not append this computation to score_history.ndjson.",
+    )
 
     # gates
-    gt = subparsers.add_parser("gates", help="Check hard constraint gates")
-    gt.add_argument("--skill", required=True)
-    gt.add_argument("--json", action="store_true")
+    gt = add(
+        "gates",
+        "Check hard constraint gates",
+        "Check the hard constraint gates (catastrophic failure, regression rate, "
+        "human intervention rate). Any failing gate is a veto that rejects a "
+        "candidate regardless of its score.",
+        "examples:\n"
+        "  ratchet.py gates --skill issue-flow\n"
+        "  ratchet.py gates --skill issue-flow --json",
+    )
+    gt.add_argument("--skill", required=True, help="Skill name to check")
+    gt.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
 
     # snapshot
-    sn = subparsers.add_parser("snapshot", help="Snapshot skill state before improvement")
-    sn.add_argument("--skill", required=True)
+    sn = add(
+        "snapshot",
+        "Snapshot skill state before improvement",
+        "Snapshot the current skill state before an improvement: creates a git "
+        "tag at ratchet/<skill>/<timestamp> and records the baseline score in "
+        "ratchet state. Run this before editing a skill.",
+        "examples:\n"
+        "  ratchet.py snapshot --skill issue-flow",
+    )
+    sn.add_argument("--skill", required=True, help="Skill name to snapshot")
 
     # evaluate
-    ev = subparsers.add_parser("evaluate", help="Evaluate improvement impact")
-    ev.add_argument("--skill", required=True)
-    ev.add_argument("--window", type=int, required=True, help="Number of post-improvement runs to evaluate")
-    ev.add_argument("--json", action="store_true")
+    ev = add(
+        "evaluate",
+        "Evaluate improvement impact",
+        "Evaluate the candidate against the baseline over a window of "
+        "post-snapshot runs. Reports the score delta versus epsilon and whether "
+        "the hard gates pass. Requires a prior 'snapshot'.",
+        "examples:\n"
+        "  ratchet.py evaluate --skill issue-flow --window 3\n"
+        "  ratchet.py evaluate --skill issue-flow --window 5 --json",
+    )
+    ev.add_argument("--skill", required=True, help="Skill name to evaluate")
+    ev.add_argument("--window", type=int, required=True,
+                    help="Number of post-improvement runs to evaluate")
+    ev.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
 
     # decide
-    dc = subparsers.add_parser("decide", help="Make keep/revert decision")
-    dc.add_argument("--skill", required=True)
-    dc.add_argument("--json", action="store_true")
+    dc = add(
+        "decide",
+        "Make keep/revert decision",
+        "Make the binary keep/revert decision from the latest evaluation. A "
+        "failed gate or a delta below -epsilon reverts the skill to its snapshot "
+        "tag; otherwise the change is kept. Requires 'snapshot' then 'evaluate'.",
+        "examples:\n"
+        "  ratchet.py decide --skill issue-flow\n"
+        "  ratchet.py decide --skill issue-flow --json",
+    )
+    dc.add_argument("--skill", required=True, help="Skill name to decide on")
+    dc.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
 
     # status
-    st = subparsers.add_parser("status", help="Show ratchet state")
-    st.add_argument("--skill", required=True)
-    st.add_argument("--json", action="store_true")
+    st = add(
+        "status",
+        "Show ratchet state",
+        "Show the current ratchet cycle state for a skill: snapshot tag, "
+        "baseline and candidate scores, delta, decision, and progress toward "
+        "the evaluation window.",
+        "examples:\n"
+        "  ratchet.py status --skill issue-flow\n"
+        "  ratchet.py status --skill issue-flow --json",
+    )
+    st.add_argument("--skill", required=True, help="Skill name to inspect")
+    st.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+
+    # history
+    hi = add(
+        "history",
+        "Show recorded score history",
+        "Show the append-only score history recorded by 'score' as a time-series "
+        "trend, with a per-entry bar and an up/down/flat marker relative to the "
+        "previous entry.",
+        "examples:\n"
+        "  ratchet.py history --skill issue-flow\n"
+        "  ratchet.py history --skill issue-flow --last 10\n"
+        "  ratchet.py history --skill issue-flow --json",
+    )
+    hi.add_argument("--skill", required=True, help="Skill name to show history for")
+    hi.add_argument("--last", type=int, default=None,
+                    help="Show only the most recent N entries")
+    hi.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
 
     return parser.parse_args()
 
@@ -699,6 +907,7 @@ def main() -> int:
         "evaluate": command_evaluate,
         "decide": command_decide,
         "status": command_status,
+        "history": command_history,
     }
     handler = commands.get(args.command)
     if not handler:

--- a/tools/flow-install/skills/autoflow/commands/autoflow.md
+++ b/tools/flow-install/skills/autoflow/commands/autoflow.md
@@ -450,9 +450,23 @@ Append to `.jarvis/context/autoflow/runs.ndjson`:
   "tests_total": 18,
   "regression_detected": false,
   "catastrophic_failure": false,
-  "approval_checkpoint": "after-spec"
+  "approval_checkpoint": "after-spec",
+  "cost_usd": 0.42,
+  "tokens_in": 180000,
+  "tokens_out": 24000
 }
 ```
+
+**Cost fields (optional, power the `c` dimension of the Layer-2 ratchet metric):**
+
+- `cost_usd` — total model spend for the run, in USD. Used directly if present.
+- `tokens_in` / `tokens_out` — token counts (also accepted as a nested
+  `"tokens": {"in": ..., "out": ...}`). When `cost_usd` is absent, cost is
+  derived from these using the `price_per_1k_input` / `price_per_1k_output`
+  rates in `program.md`. Runs with no cost signal are excluded from the cost
+  average rather than counted as free, so `c` stays honest until
+  instrumentation lands. `c` is normalized against `target_cost` (per-run USD
+  budget).
 
 ### State: EVALUATE_QUALITY
 


### PR DESCRIPTION
## Summary

Instruments the autoresearch ratchet loop (`tools/flow-install/skills/_shared/ratchet.py`) so improvements are **observable**, its economics are **honest**, and its self-modification is **safe and auditable**. Three related threads, one file surface plus docs and tests.

Closes #27. Closes #28.

## What changed

### Score history + comprehensive help (#27, #28)
- Every `ratchet.py score` appends to an append-only `.jarvis/context/autoflow/score_history.ndjson` (timestamp, skill, layer, score, f/p/q/r, plus h/c on layer 2). `--no-history` opts out.
- New `history` subcommand renders the recorded scores as a time-series trend with per-entry bars and up/down/flat markers.
- Top-level and **every** subcommand (score, gates, snapshot, evaluate, decide, status, history) now carry descriptions and usage examples via `RawDescriptionHelpFormatter`.

### Real cost tracking (the `c` dimension)
Previously `c` read `run.get("cost", 0.0)` and the documented run schema had no cost field, so `c` was always 0 and never affected the score.
- `run_cost_usd()` resolves a run's cost from `cost_usd`, then token counts (`tokens_in`/`tokens_out`, or nested `tokens`) priced via configurable per-1K rates, then legacy `cost` for back-compat.
- `c` now averages **only** over runs that carry a cost signal, so missing instrumentation reads as `c=0` rather than counting runs as free.
- Raw aggregates gain `avg_cost_usd`, `runs_with_cost`, and token totals. Run-record schema and `program.md` document the new fields and knobs (`target_cost`, `price_per_1k_input/output`).
- Note: token×rate is a best-effort estimate; a directly recorded `cost_usd` is preferred (handles prompt caching, batch discounts, and per-model runs correctly) and takes priority.

### Safe, auditable auto-revert
`decide` previously ran an unguarded `git checkout <tag> -- <skill_path>` with no dry-run, no orphan handling, and no evidence trail.
- Builds a **revert plan** (files to restore; tracked/untracked orphan files a path-checkout would leave behind) and verifies the snapshot tag exists before touching git.
- Every revert writes an **evidence diff + JSON manifest** to `.jarvis/context/autoflow/reverts/` and records it in ratchet state.
- `--dry-run` reports the decision and revert plan **without mutating git or state**; `--clean` removes orphan files for a complete revert.

## Tests

New stdlib `unittest` suite at `tests/ratchet/test_ratchet_history.py` (no external deps):
- score history: append-only semantics, JSON validity, required keys, layer-2 fields, skill filtering
- cost: `cost_usd` / tokens×rate / legacy / no-signal resolution
- revert safety: tag existence, orphan detection, missing-tag abort without mutation, evidence write, `--clean`
- help: top-level lists all subcommands; each subcommand `--help` has an example

```
$ python3 tests/ratchet/test_ratchet_history.py
Ran 16 tests in ~5s — OK
```

Also verified: `uvx ruff check` clean on changed files, `pnpm skills:validate` passes. Runtime artifacts live under the already-gitignored `.jarvis/context/autoflow/`.

## Notes for reviewers
- All behavior is backward compatible: existing run records without cost fields keep working (`c=0`), and `decide` with no new flags behaves as before but with added safety + evidence.
- Happy to split the cost/revert work into a follow-up PR if you'd prefer #27/#28 land on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cost-aware score normalization using direct cost or token-based estimates.
  * Added persistent score history with filtering, trend views, JSON output, and an opt-out option.
  * Added safer revert previews with dry-run support, orphan-file handling, cleanup, and audit evidence.

* **Documentation**
  * Documented cost configuration, run cost fields, score history, and related commands.

* **Tests**
  * Added coverage for history, cost extraction, revert safety, orphan files, and command help output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->